### PR TITLE
Allow custom locations to be added

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: orderly2
 Title: Orderly Next Generation
-Version: 1.99.1
+Version: 1.99.2
 Authors@R: c(person("Rich", "FitzJohn", role = c("aut", "cre"),
                     email = "rich.fitzjohn@gmail.com"),
              person("Robert", "Ashton", role = "aut"),

--- a/R/outpack_config.R
+++ b/R/outpack_config.R
@@ -217,8 +217,14 @@ config_serialise <- function(config, path) {
   config$logging <- lapply(config$logging, scalar)
 
   prepare_location <- function(loc) {
+    args <- loc$args[[1]]
+    if (length(args) == 0) {
+      args <- set_names(list(), character())
+    } else {
+      args <- lapply(args, scalar)
+    }
     c(lapply(loc[setdiff(names(loc), "args")], scalar),
-      list(args = lapply(loc$args[[1]], scalar)))
+      list(args = args))
   }
   config$location <- lapply(seq_len(nrow(config$location)), function(i) {
     prepare_location(config$location[i, ])
@@ -229,8 +235,8 @@ config_serialise <- function(config, path) {
 
 
 config_update <- function(config, root) {
-  root$config <- config
   config_write(config, root$path)
+  root$config <- config
   root
 }
 

--- a/R/outpack_misc.R
+++ b/R/outpack_misc.R
@@ -2,7 +2,7 @@
 local <- "local"
 orphan <- "orphan"
 location_reserved_name <- c(local, orphan)
-location_types <- c(local, orphan, "path", "http")
+location_types <- c(local, orphan, "path", "http", "custom")
 re_id <- "^([0-9]{8}-[0-9]{6}-[[:xdigit:]]{8})$"
 
 

--- a/R/util.R
+++ b/R/util.R
@@ -373,3 +373,13 @@ error_near_match <- function(title, x, hint, join, possibilities) {
   }
   err
 }
+
+
+check_symbol_from_str <- function(str, name) {
+  assert_scalar_character(str, name)
+  dat <- strsplit(str, "(?<=[^:])::(?=[^:])", perl = TRUE)[[1]]
+  if (length(dat) != 2) {
+    stop(sprintf("Expected fully qualified name for '%s'", name))
+  }
+  list(namespace = dat[[1]], symbol = dat[[2]])
+}

--- a/inst/outpack/schema/config.json
+++ b/inst/outpack/schema/config.json
@@ -57,7 +57,7 @@
                         "type": "number"
                     },
                     "type": {
-                        "enum": ["http", "local", "orphan", "path"]
+                        "type": "string"
                     }
                 },
                 "required": ["name", "id", "priority", "type"]

--- a/man/outpack_location_add.Rd
+++ b/man/outpack_location_add.Rd
@@ -65,6 +65,21 @@ authentication.
 \item \code{url}: The location of the server, including protocol, for
 example \verb{http://example.com:8080}
 }
+
+\strong{Custom locations}:
+
+All outpack implementations are expected to support path and http
+locations, with the standard arguments above.  But we expect that
+some implementations will support custom locations, and that the
+argument lists for these may vary between implementations. To
+allow this, you can pass a location of type "custom" with a list
+of arguments.  We expect an argument 'driver' to be present among
+this list.  For an example of this in action, see the
+\href{https://mrc-ide.github.io/outpack.sharepoint}{\code{outpack.sharepoint}}
+package.
+
+\emph{Be warned that we may change this interface in future, in which
+case you may need to update your configuration.}
 }
 \section{Warning}{
 

--- a/tests/testthat/test-util.R
+++ b/tests/testthat/test-util.R
@@ -165,3 +165,15 @@ test_that("can get near matches", {
     near_match("apple", x, 2, 3),
     c("apples", "applez", "appell"))
 })
+
+
+test_that("validate namespaced symbol strings", {
+  expect_equal(check_symbol_from_str("a::b", "x"),
+               list(namespace = "a", symbol = "b"))
+  expect_error(check_symbol_from_str("b", "x"),
+               "Expected fully qualified name for 'x'")
+  expect_error(check_symbol_from_str("a:::b", "x"),
+               "Expected fully qualified name for 'x'")
+  expect_error(check_symbol_from_str("a::b::c", "x"),
+               "Expected fully qualified name for 'x'")
+})


### PR DESCRIPTION
This is a bit ropey, and worth chatting about. In particular, I wonder if instead of "custom" type we might use something like the fully qualified driver name as the type? Not sure, really. The issue here is that we expect that other outpack implementations (e.g. a python or rust one) pointed at this archive need to know that they don't need to stress about the location entry.

Look at https://github.com/mrc-ide/outpack.sharepoint/pull/1 for the implementation of a custom driver that inspired this.