### PR TITLE
Better parameter errors

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -16,6 +16,7 @@ URL: https://github.com/mrc-ide/orderly2
 BugReports: https://github.com/mrc-ide/orderly2/issues
 Imports:
     R6,
+    cli,
     fs,
     gert,
     jsonlite,

--- a/R/run.R
+++ b/R/run.R
@@ -111,7 +111,8 @@ orderly_run <- function(name, parameters = NULL, envir = NULL,
 
   dat <- orderly_read(src)
 
-  parameters <- check_parameters(parameters, dat$parameters)
+  parameters <- check_parameters(parameters, dat$parameters,
+                                 environment())
 
   orderly_validate(dat, src)
 
@@ -225,15 +226,16 @@ check_produced_artefacts <- function(path, artefacts) {
 ## to relax additional parameters here later, but that requires some
 ## thinking about what to do with them (do they get passed into the
 ## environment etc or not? do they get validated?)
-check_parameters <- function(given, spec) {
+check_parameters <- function(given, spec, call) {
   if (length(given) > 0) {
     assert_named(given, unique = TRUE)
   }
 
   if (length(given) > 0 && is.null(spec)) {
-    cli::cli_abort(c(
-      "Parameters given, but none declared",
-      i = "Did you forget 'orderly2::orderly_parameter()"))
+    cli::cli_abort(
+      c("Parameters given, but none declared",
+        i = "Did you forget 'orderly2::orderly_parameter()"),
+      call = call)
   }
 
   is_required <- vlapply(spec, is.null)
@@ -241,22 +243,26 @@ check_parameters <- function(given, spec) {
   extra <- setdiff(names(given), names(spec))
 
   if (length(msg) > 0L) {
-    cli::cli_abort(error_near_match(
-      "Missing parameters",
-      msg,
-      "You have extra parameters, possibly misspelt?",
-      "could be your",
-      extra))
+    cli::cli_abort(
+      error_near_match(
+        "Missing parameters",
+        msg,
+        "You have extra parameters, possibly misspelt?",
+        "could be your",
+        extra),
+      call = call)
   }
 
   if (length(extra) > 0L) {
     unused <- setdiff(names(spec), names(given))
-    cli::cli_abort(error_near_match(
-      "Extra parameters",
-      extra,
-      "You have extra parameters, possibly misspelt?",
-      "should perhaps be",
-      unused))
+    cli::cli_abort(
+      error_near_match(
+        "Extra parameters",
+        extra,
+        "You have extra parameters, possibly misspelt?",
+        "should perhaps be",
+        unused),
+      call = call)
   }
 
   if (length(spec) == 0) {

--- a/R/run.R
+++ b/R/run.R
@@ -230,16 +230,35 @@ check_parameters <- function(given, spec) {
     assert_named(given, unique = TRUE)
   }
 
-  is_required <- vlapply(spec, is.null)
+  if (is.null(spec)) {
+    cli::cli_abort(c(
+      "Parameters given, but none declared",
+      i = "Did you forget 'orderly2::orderly_parameter()"))
+  }
 
+  is_required <- vlapply(spec, is.null)
   msg <- setdiff(names(spec)[is_required], names(given))
-  if (length(msg) > 0L) {
-    stop("Missing parameters: ", paste(squote(msg), collapse = ", "))
-  }
   extra <- setdiff(names(given), names(spec))
-  if (length(extra) > 0L) {
-    stop("Extra parameters: ", paste(squote(extra), collapse = ", "))
+
+  if (length(msg) > 0L) {
+    cli::cli_abort(error_near_match(
+      "Missing parameters",
+      msg,
+      "You have extra parameters, possibly misspelt?",
+      "could be your",
+      extra))
   }
+
+  if (length(extra) > 0L) {
+    unused <- setdiff(names(spec), names(given))
+    cli::cli_abort(error_near_match(
+      "Extra parameters",
+      extra,
+      "You have extra parameters, possibly misspelt?",
+      "should perhaps be",
+      unused))
+  }
+
   if (length(spec) == 0) {
     return(NULL)
   }

--- a/R/run.R
+++ b/R/run.R
@@ -230,7 +230,7 @@ check_parameters <- function(given, spec) {
     assert_named(given, unique = TRUE)
   }
 
-  if (is.null(spec)) {
+  if (length(given) > 0 && is.null(spec)) {
     cli::cli_abort(c(
       "Parameters given, but none declared",
       i = "Did you forget 'orderly2::orderly_parameter()"))

--- a/R/util.R
+++ b/R/util.R
@@ -347,7 +347,7 @@ near_match <- function(x, possibilities, threshold = 2, max_matches = 5) {
   }
   d <- set_names(drop(adist(x, possibilities, ignore.case = TRUE)),
                  possibilities)
-  utils::head(names(sort(d[d < threshold], decreasing = TRUE)), max_matches)
+  utils::head(names(sort(d[d <= threshold])), max_matches)
 }
 
 

--- a/R/util.R
+++ b/R/util.R
@@ -339,3 +339,37 @@ string_starts_with <- function(sub, str) {
 string_drop_prefix <- function(sub, str) {
   substr(str, nchar(sub) + 1, nchar(str))
 }
+
+
+near_match <- function(x, possibilities, threshold = 2, max_matches = 5) {
+  if (length(possibilities) == 0) {
+    return(character())
+  }
+  d <- set_names(drop(adist(x, possibilities, ignore.case = TRUE)),
+                 possibilities)
+  utils::head(names(sort(d[d < threshold], decreasing = TRUE)), max_matches)
+}
+
+
+near_matches <- function(x, ...) {
+  set_names(lapply(x, near_match, ...), x)
+}
+
+
+error_near_match <- function(title, x, hint, join, possibilities) {
+  err <- sprintf("%s: %s", title, paste(squote(x), collapse = ", "))
+  near <- near_matches(x, possibilities)
+  i <- lengths(near) > 0
+  if (any(i)) {
+    near_str <- vcapply(which(lengths(near) > 0), function(i) {
+      sprintf("'%s': %s %s",
+              names(near)[[i]],
+              join,
+              paste(squote(near[[i]]), collapse = ", "))
+    })
+    err <- c(err,
+             i = hint,
+             set_names(near_str, rep("*", length(near_str))))
+  }
+  err
+}

--- a/tests/testthat/test-parameters.R
+++ b/tests/testthat/test-parameters.R
@@ -14,19 +14,41 @@ test_that("prevent missing parameters", {
   expect_error(
     check_parameters(list(a = 1), list(a = NULL, b = 2, c = NULL)),
     "Missing parameters: 'c'")
+
+  err <- expect_error(
+    check_parameters(list(thing = 1), list(things = NULL)),
+    "Missing parameters: 'things'")
+  expect_equal(
+    err$body,
+    c(i = "You have extra parameters, possibly misspelt?",
+      "*" = "'things': could be your 'thing'"))
 })
 
 
 test_that("prevent extra parameters", {
-  expect_error(
+  err <- expect_error(
     check_parameters(list(a = 1), NULL),
-    "Extra parameters: 'a'")
+    "Parameters given, but none declared")
+  expect_equal(err$body,
+               c(i = "Did you forget 'orderly2::orderly_parameter()"))
+
   expect_error(
-    check_parameters(list(a = 1, b = 2), NULL),
+    check_parameters(list(a = 1, b = 2), list()),
     "Extra parameters: 'a', 'b'")
   expect_error(
     check_parameters(list(a = 1, b = 2), list(a = NULL)),
     "Extra parameters: 'b'")
+})
+
+
+test_that("prevent extra parameters that might be misspelt optional ones", {
+  err <- expect_error(
+    check_parameters(list(apple = 1), list(apples = 2)),
+    "Extra parameters: 'apple'")
+  expect_equal(
+    err$body,
+    c("i" = "You have extra parameters, possibly misspelt?",
+      "*" = "'apple': should perhaps be 'apples'"))
 })
 
 

--- a/tests/testthat/test-util.R
+++ b/tests/testthat/test-util.R
@@ -151,3 +151,17 @@ test_that("Descend failure", {
   expect_null(find_file_descend(".orderly_foobar", "/", path))
   expect_null(find_file_descend(".orderly_foobar", "/", "/"))
 })
+
+
+test_that("can get near matches", {
+  x <- c("apples", "applez", "appell", "applly")
+  expect_equal(
+    near_match("apple", x),
+    c("apples", "applez", "appell", "applly"))
+  expect_equal(
+    near_match("apple", x, 1),
+    c("apples", "applez"))
+  expect_equal(
+    near_match("apple", x, 2, 3),
+    c("apples", "applez", "appell"))
+})


### PR DESCRIPTION
This PR tidies up error messages for parameters that are not correct when running a report:

* if no `orderly::orderly_parameters()` call we include a suggestion that the report might want that
* if a parameter is missing but there are near misses amongst unused parameters, we suggest these
* if a parameter is unused and there are also optional parameters that are not given and near misses we suggest those.

In order to make the error messages easy to work with I've used `cli`'s error formatting, based on `rlang`: see https://www.tidyverse.org/blog/2021/12/rlang-1-0-0-errors/ though I think there might be other posts on this too.

The easiest way to see the error text is to try the examples changed in the tests, for example:

```
> check_parameters(list(thing = 1), list(things = NULL))
Error in `check_parameters()`:
! Missing parameters: 'things'
ℹ You have extra parameters, possibly misspelt?
• 'things': could be your 'thing'
Run `rlang::last_trace()` to see where the error occurred.
```