### PR TITLE
Allow environment lookup

### DIFF
--- a/R/metadata.R
+++ b/R/metadata.R
@@ -262,13 +262,17 @@ orderly_dependency <- function(name, query, use) {
   if (ctx$is_active) {
     outpack_packet_use_dependency(ctx$packet, query, use,
                                   search_options = search_options,
+                                  envir = ctx$env,
                                   overwrite = TRUE)
   } else {
     id <- outpack_search(query, parameters = ctx$parameters,
-                         options = search_options, root = ctx$root)
+                         envir = ctx$env,
+                         options = search_options,
+                         root = ctx$root)
     outpack_copy_files(id, use, ctx$path,
                        allow_remote = search_options$allow_remote,
-                       overwrite = TRUE, root = ctx$root)
+                       overwrite = TRUE,
+                       root = ctx$root)
   }
 
   invisible()

--- a/R/outpack_packet.R
+++ b/R/outpack_packet.R
@@ -263,11 +263,18 @@ outpack_packet_run <- function(packet, script, envir = .GlobalEnv) {
 ##' @param search_options Optional search options for restricting the
 ##'   search (see [orderly2::outpack_search] for details)
 ##'
+##' @param envir Optional environment for `environment:` lookups; the
+##'   default is to use the parent frame, but other suitable options
+##'   are the global environment or the environment of the script you
+##'   are running (this only relevant if you have `environment:`
+##'   lookups in `query`).
+##'
 ##' @param overwrite Overwrite files at the destination; this is
 ##'   typically what you want, but set to `FALSE` if you would prefer
 ##'   that an error be thrown if the destination file already exists.
 outpack_packet_use_dependency <- function(packet, query, files,
                                           search_options = NULL,
+                                          envir = parent.frame(),
                                           overwrite = TRUE) {
   packet <- check_current_packet(packet)
   query <- as_outpack_query(query)
@@ -280,8 +287,11 @@ outpack_packet_use_dependency <- function(packet, query, files,
       "Did you forget latest(...)?"))
   }
 
-  id <- outpack_search(query, parameters = packet$parameters,
-                       options = search_options, root = packet$root)
+  id <- outpack_search(query,
+                       parameters = packet$parameters,
+                       envir = envir,
+                       options = search_options,
+                       root = packet$root)
   if (is.na(id)) {
     ## TODO: this is where we would want to consider explaining what
     ## went wrong; because that comes with a cost we should probably

--- a/R/query_search.R
+++ b/R/query_search.R
@@ -188,8 +188,11 @@ query_eval_subquery <- function(query, query_env) {
   if (!subquery[[name]]$evaluated) {
     ## TODO: should we really not allow parameters here? Feels like
     ## they might be relevant?
-    result <- query_eval(subquery[[name]]$parsed, query_env$index,
-                         parameters = NULL, subquery)
+    subquery_env <- list(index = query_env$index,
+                         parameters = NULL,
+                         environment = query_env$environment,
+                         subquery = subquery)
+    result <- query_eval(subquery[[name]]$parsed, subquery_env)
     subquery[[name]]$result <- result
     subquery[[name]]$evaluated <- TRUE
   }
@@ -202,6 +205,7 @@ query_eval_dependency <- function(query, query_env) {
   ## were usedby or used in this one, so find parents/children without scope
   ## and apply scope later when finding the results of the main query.
   id <- query_eval(query$args[[1]], query_env)
+  index <- query_env$index
   switch(query$name,
          usedby = index$get_packet_depends(id, query$args[[2]]$value),
          uses = index$get_packet_uses(id, query$args[[2]]$value))

--- a/man/outpack_packet.Rd
+++ b/man/outpack_packet.Rd
@@ -30,6 +30,7 @@ outpack_packet_use_dependency(
   query,
   files,
   search_options = NULL,
+  envir = parent.frame(),
   overwrite = TRUE
 )
 
@@ -78,7 +79,11 @@ marked immutable have not been changed)}
 relative path).  This function can be safely called multiple
 times within a single packet run (or zero times!) as needed.}
 
-\item{envir}{Environment in which to run the script}
+\item{envir}{Optional environment for \verb{environment:} lookups; the
+default is to use the parent frame, but other suitable options
+are the global environment or the environment of the script you
+are running (this only relevant if you have \verb{environment:}
+lookups in \code{query}).}
 
 \item{query}{An \link{outpack_query} object, or something
 (e.g., a string) that can be trivially converted into one.}

--- a/man/outpack_search.Rd
+++ b/man/outpack_search.Rd
@@ -4,7 +4,13 @@
 \alias{outpack_search}
 \title{Query outpack's database}
 \usage{
-outpack_search(..., parameters = NULL, options = NULL, root = NULL)
+outpack_search(
+  ...,
+  parameters = NULL,
+  envir = parent.frame(),
+  options = NULL,
+  root = NULL
+)
 }
 \arguments{
 \item{...}{Arguments passed through to \link{outpack_query}, perhaps
@@ -12,6 +18,11 @@ just a query expression}
 
 \item{parameters}{Optionally, a named list of parameters to substitute
 into the query (using the \verb{this:} prefix)}
+
+\item{envir}{Optionally, an environment to substitute into the
+query (using the \verb{environment:} prefix). The default here is to
+use the calling environment, but you can explicitly pass this in
+if you want to control where this lookup happens.}
 
 \item{options}{Optionally, a \link{outpack_search_options}
 object for controlling how the search is performed, and which

--- a/tests/testthat/test-query-search.R
+++ b/tests/testthat/test-query-search.R
@@ -121,9 +121,30 @@ test_that("Can filter based on given values", {
   expect_error(
     outpack_search(quote(latest(parameter:a == this:x)),
                   parameters = list(a = 3), root = root),
-    paste0("Did not find 'x' within given parameters ('a')\n",
+    paste0("Did not find 'x' within given parameters (containing 'a')\n",
            "  - while evaluating this:x\n",
            "  - within           latest(parameter:a == this:x)"),
+    fixed = TRUE)
+})
+
+
+test_that("can use variables from the environment when searching", {
+  root <- create_temporary_root(use_file_store = TRUE)
+
+  x1 <- vcapply(1:3, function(i) create_random_packet(root, "x", list(a = 1)))
+  x2 <- vcapply(1:3, function(i) create_random_packet(root, "x", list(a = 2)))
+
+  env <- new.env()
+  env$x <- 1
+  expect_equal(
+    outpack_search(quote(latest(parameter:a == environment:x)),
+                   envir = env, root = root),
+    x1[[3]])
+
+  expect_error(
+    outpack_search(quote(latest(parameter:a == environment:other)),
+                   envir = env, root = root),
+    "Did not find 'other' within given environment (containing 'x')",
     fixed = TRUE)
 })
 

--- a/tests/testthat/test-query-search.R
+++ b/tests/testthat/test-query-search.R
@@ -177,7 +177,8 @@ test_that("switch statements will prevent regressions", {
     "Unhandled expression [outpack bug - please report]",
     fixed = TRUE)
   expect_error(
-    query_eval_lookup(list(name = "custom:orderly:displayname")),
+    query_eval_lookup(list(name = "custom:orderly:displayname"),
+                      new.env(parent = emptyenv())),
     "Unhandled lookup [outpack bug - please report]",
     fixed = TRUE)
   expect_error(

--- a/tests/testthat/test-query.R
+++ b/tests/testthat/test-query.R
@@ -205,7 +205,9 @@ test_that("construct a query", {
   expect_setequal(names(obj), c("value", "info", "subquery"))
   expect_s3_class(obj$value, "outpack_query_component")
   expect_equal(obj$value, query_parse("latest", "latest", emptyenv()))
-  expect_equal(obj$info, list(single = TRUE, parameters = character()))
+  expect_equal(obj$info, list(single = TRUE,
+                              parameters = character(),
+                              environment = character()))
   expect_equal(obj$subquery, list())
 })
 
@@ -232,7 +234,6 @@ test_that("report on parameters used in the query", {
   expect_equal(f(quote(parameter:x < this:a && this:a > this:b)),
                c("a", "b"))
 })
-
 
 test_that("report on environment variables used in the query", {
   f <- function(x) {

--- a/tests/testthat/test-query.R
+++ b/tests/testthat/test-query.R
@@ -228,9 +228,21 @@ test_that("report on parameters used in the query", {
     outpack_query(x)$info$parameters
   }
   expect_equal(f(quote(latest())), character())
-  expect_equal(f(quote(parameter:a < this:a)), "a")
-  expect_equal(f(quote(parameter:a < this:a && this:a > this:b)),
+  expect_equal(f(quote(parameter:x < this:a)), "a")
+  expect_equal(f(quote(parameter:x < this:a && this:a > this:b)),
                c("a", "b"))
+})
+
+
+test_that("report on environment variables used in the query", {
+  f <- function(x) {
+    outpack_query(x)$info$environment
+ }
+  expect_equal(f(quote(latest())), character())
+  expect_equal(f(quote(parameter:x < environment:a)), "a")
+  expect_equal(
+    f(quote(parameter:x < environment:a && environment:a > environment:b)),
+    c("a", "b"))
 })
 
 

--- a/tests/testthat/test-query.R
+++ b/tests/testthat/test-query.R
@@ -22,7 +22,8 @@ test_that("empty query is possible", {
       list(value = query_parse(NULL, NULL, new.env(parent = emptyenv())),
            subquery = list(),
            info = list(single = FALSE,
-                       parameters = character())),
+                       parameters = character(),
+                       environment = character())),
       class = "outpack_query"))
 })
 


### PR DESCRIPTION
This PR adds something required for us to be able to practically have a loop where we do:

```
for (r in regions) {
  orderly2::orderly_dependency("data", "parameter:region == environment:region", ...)
}
```

(there's still some issues around how we do the renaming of files in the dots there, ignored for now). This PR adds another explicit lookup.

Two things to be aware of here:

* anything that uses `parameter:x` could get away with `environment:x` but probably people should prefer the former, and we might prevent the latter in strict mode. Thoughts on this very welcome (including if they are an issue for now or later)
* is the name `environment:` right? I wondered about `local:` or `dynamic:` - this will form part of the spec so a general term is useful, but it will also be almost impossible for the rust version (for example) to support it

This PR is related to #40, which also uses the environment