### PR TITLE
mrc-4389: better error message on missing report

### DIFF
--- a/R/orderly.R
+++ b/R/orderly.R
@@ -1,0 +1,4 @@
+orderly_list_src <- function(path) {
+  pos <- fs::dir_ls(file.path(path, "src"), type = "directory")
+  basename(pos)[file_exists(file.path(pos, "orderly.R"))]
+}

--- a/R/run.R
+++ b/R/run.R
@@ -423,21 +423,26 @@ validate_orderly_directory <- function(name, root, call) {
   if (!file_exists(file.path(root$path, "src", name, "orderly.R"))) {
     src <- file.path(root$path, "src", name)
     err <- sprintf("Did not find orderly report '%s'", name)
-    if (file_exists(src)) {
-      if (is_directory(src)) {
-        err <- c(err, x = "This path exists but does not contain 'orderly.R'")
-      } else {
-        err <- c(err, x = "This path exists but is not a directory")
-      }
+    if (!file_exists(src)) {
+      detail <- sprintf("The path 'src/%s' does not exist", name)
+    } else if (is_directory(src)) {
+      detail <- sprintf(
+        "The path 'src/%s' exists but does not contain 'orderly.R'",
+        name)
     } else {
-      err <- c(err, x = "This path does not exist")
+      detail <- sprintf(
+        "The path 'src/%s' exists but is not a directory",
+        name)
     }
+    err <- c(err, x = detail)
     near <- near_match(name, orderly_list_src(root$path))
     if (length(near) > 0) {
       hint <- sprintf("Did you mean %s",
                       paste(squote(near), collapse = ", "))
       err <- c(err, i = hint)
     }
+    err <- c(err, i = sprintf("Looked relative to orderly root at '%s'",
+                              root$path))
     cli::cli_abort(err, call = call)
   }
 }

--- a/R/run.R
+++ b/R/run.R
@@ -104,7 +104,7 @@ orderly_run <- function(name, parameters = NULL, envir = NULL,
                         logging_console = NULL, logging_threshold = NULL,
                         search_options = NULL, root = NULL, locate = TRUE) {
   root <- orderly_root(root, locate)
-  validate_orderly_directory(name, root)
+  validate_orderly_directory(name, root, environment())
 
   envir <- envir %||% .GlobalEnv
   assert_is(envir, "environment")
@@ -418,7 +418,7 @@ orderly_packet_cleanup_failure <- function(p) {
 }
 
 
-validate_orderly_directory <- function(name, root) {
+validate_orderly_directory <- function(name, root, call) {
   assert_scalar_character(name)
   if (!file_exists(file.path(root$path, "src", name, "orderly.R"))) {
     src <- file.path(root$path, "src", name)
@@ -438,6 +438,6 @@ validate_orderly_directory <- function(name, root) {
                       paste(squote(near), collapse = ", "))
       err <- c(err, i = hint)
     }
-    cli::cli_abort(err)
+    cli::cli_abort(err, call = call)
   }
 }

--- a/R/run.R
+++ b/R/run.R
@@ -109,6 +109,7 @@ orderly_run <- function(name, parameters = NULL, envir = NULL,
   envir <- envir %||% .GlobalEnv
   assert_is(envir, "environment")
 
+  src <- file.path(root$path, "src", name)
   dat <- orderly_read(src)
 
   parameters <- check_parameters(parameters, dat$parameters,
@@ -419,7 +420,7 @@ orderly_packet_cleanup_failure <- function(p) {
 
 validate_orderly_directory <- function(name, root) {
   assert_scalar_character(name)
-  if (!file_exists(file.path(root$path, "src", name, "ordery.R"))) {
+  if (!file_exists(file.path(root$path, "src", name, "orderly.R"))) {
     src <- file.path(root$path, "src", name)
     err <- sprintf("Did not find orderly report '%s'", name)
     if (file_exists(src)) {

--- a/tests/testthat/test-run.R
+++ b/tests/testthat/test-run.R
@@ -843,8 +843,9 @@ test_that("nice error if running nonexistant report", {
     orderly_run("xplicit", root = path, envir = env),
     "Did not find orderly report 'xplicit'")
   expect_equal(err$body,
-               c(x = "This path does not exist",
-                 i = "Did you mean 'explicit', 'implicit'"))
+               c(x = "The path 'src/xplicit' does not exist",
+                 i = "Did you mean 'explicit', 'implicit'",
+                 i = sprintf("Looked relative to orderly root at '%s'", path)))
 })
 
 
@@ -858,43 +859,46 @@ test_that("validation of orderly directories", {
   err <- expect_error(
     validate_orderly_directory("foo", root),
     "Did not find orderly report 'foo'")
-  expect_equal(err$body, c(x = "This path does not exist"))
+  expect_equal(err$body[1],
+               c(x = "The path 'src/foo' does not exist"))
 
   file.create(file.path(path, "src", "foo"))
   err <- expect_error(
     validate_orderly_directory("foo", root),
     "Did not find orderly report 'foo'")
-  expect_equal(err$body, c(x = "This path exists but is not a directory"))
+  expect_equal(err$body[1],
+               c(x = "The path 'src/foo' exists but is not a directory"))
 
   fs::dir_create(file.path(path, "src", "bar"))
   err <- expect_error(
     validate_orderly_directory("bar", root),
     "Did not find orderly report 'bar'")
-  expect_equal(err$body,
-               c(x = "This path exists but does not contain 'orderly.R'"))
-
+  expect_equal(
+    err$body[1],
+    c(x = "The path 'src/bar' exists but does not contain 'orderly.R'"))
 
   hint <- sprintf("Did you mean %s", paste(squote(nms[1:5]), collapse = ", "))
   err <- expect_error(
     validate_orderly_directory("example_z", root),
     "Did not find orderly report 'example_z'")
-  expect_equal(err$body,
-               c(x = "This path does not exist",
+  expect_equal(err$body[1:2],
+               c(x = "The path 'src/example_z' does not exist",
                  i = hint))
 
   file.create(file.path(path, "src", "example_z"))
   err <- expect_error(
     validate_orderly_directory("example_z", root),
     "Did not find orderly report 'example_z'")
-  expect_equal(err$body,
-               c(x = "This path exists but is not a directory",
+  expect_equal(err$body[1:2],
+               c(x = "The path 'src/example_z' exists but is not a directory",
                  i = hint))
 
   fs::dir_create(file.path(path, "src", "example_x"))
   err <- expect_error(
     validate_orderly_directory("example_x", root),
     "Did not find orderly report 'example_x'")
-  expect_equal(err$body,
-               c(x = "This path exists but does not contain 'orderly.R'",
-                 i = hint))
+  expect_equal(
+    err$body[1:2],
+    c(x = "The path 'src/example_x' exists but does not contain 'orderly.R'",
+      i = hint))
 })

--- a/tests/testthat/test-run.R
+++ b/tests/testthat/test-run.R
@@ -857,7 +857,7 @@ test_that("validation of orderly directories", {
   nms <- sprintf("example_%s", letters[1:8])
   fs::dir_create(file.path(path, "src", nms))
   file.create(file.path(path, "src", nms, "orderly.R"))
-  hint_root <- sprintf("Looked relative to orderly root at '%s'", path)
+  hint_root <- sprintf("Looked relative to orderly root at '%s'", root$path)
 
   err <- expect_error(
     validate_orderly_directory("foo", root),

--- a/tests/testthat/test-run.R
+++ b/tests/testthat/test-run.R
@@ -844,7 +844,7 @@ test_that("nice error if running nonexistant report", {
     "Did not find orderly report 'xplicit'")
   expect_equal(err$body,
                c(x = "This path does not exist",
-                 i = "Did you mean 'explicit'"))
+                 i = "Did you mean 'explicit', 'implicit'"))
 })
 
 


### PR DESCRIPTION
Builds on #32, using the same "did you mean" type approach. It turns out there are *lots* of ways of not finding a report, but this should guide people reasonably - it's nicer than what we had in orderly1!

~Merge after #32, contains those commits~