### PR TITLE
Allow empty queries to return everything

### DIFF
--- a/R/query.R
+++ b/R/query.R
@@ -3,7 +3,7 @@
 ##'
 ##' @title Construct outpack query
 ##'
-##' @param expr The query expression
+##' @param expr The query expression. A `NULL` expression matches everything.
 ##'
 ##' @param name Optionally, the name of the packet to scope the query on. This
 ##'   will be intersected with `scope` arg and is a shorthand way of running
@@ -48,6 +48,9 @@ outpack_query <- function(expr, name = NULL, scope = NULL, subquery = NULL) {
 
 
 as_outpack_query <- function(expr, ...) {
+  if (missing(expr)) {
+    expr <- NULL
+  }
   if (inherits(expr, "outpack_query")) {
     if (...length() > 0) {
       stop("If 'expr' is an 'outpack_query', no additional arguments allowed")
@@ -71,6 +74,7 @@ query_parse <- function(expr, context, subquery_env) {
       }
       expr <- expr[[1L]]
     }
+  } else if (is.null(expr)) {
   } else if (!is.language(expr)) {
     stop("Invalid input for query")
   }
@@ -107,6 +111,7 @@ query_component <- function(type, expr, context, args, ...) {
 query_parse_expr <- function(expr, context, subquery_env) {
   type <- query_parse_check_call(expr, context)
   fn <- switch(type,
+               empty = query_parse_empty,
                test = query_parse_test,
                group = query_parse_group,
                latest = query_parse_latest,
@@ -116,6 +121,11 @@ query_parse_expr <- function(expr, context, subquery_env) {
                ## normally unreachable
                stop("Unhandled expression [outpack bug - please report]"))
   fn(expr, context, subquery_env)
+}
+
+
+query_parse_empty <- function(expr, context, subquery_env) {
+  query_component("empty", expr, context, list())
 }
 
 
@@ -301,6 +311,10 @@ query_eval_error <- function(msg, expr, context) {
 
 
 query_parse_check_call <- function(expr, context) {
+  if (is.null(expr)) {
+    return("empty")
+  }
+
   if (!is.call(expr)) {
     query_parse_error(sprintf(
       "Invalid query '%s'; expected some sort of expression",

--- a/R/query.R
+++ b/R/query.R
@@ -74,8 +74,7 @@ query_parse <- function(expr, context, subquery_env) {
       }
       expr <- expr[[1L]]
     }
-  } else if (is.null(expr)) {
-  } else if (!is.language(expr)) {
+  } else if (!(is.null(expr) || is.language(expr))) {
     stop("Invalid input for query")
   }
 

--- a/R/query_search.R
+++ b/R/query_search.R
@@ -129,6 +129,7 @@ query_eval <- function(query, index, parameters, subquery) {
   switch(query$type,
          literal = query$value,
          lookup = query_eval_lookup(query, index, parameters),
+         empty = query_eval_empty(query, index, parameters, subquery),
          group = query_eval_group(query, index, parameters, subquery),
          test = query_eval_test(query, index, parameters, subquery),
          latest = query_eval_latest(query, index, parameters, subquery),
@@ -202,6 +203,11 @@ query_eval_lookup <- function(query, index, parameters) {
                                 query$context),
          ## Normally unreachable
          stop("Unhandled lookup [outpack bug - please report]"))
+}
+
+
+query_eval_empty <- function(query, index, parameters, subquery) {
+  index$index$id
 }
 
 

--- a/man/outpack_query.Rd
+++ b/man/outpack_query.Rd
@@ -7,7 +7,7 @@
 outpack_query(expr, name = NULL, scope = NULL, subquery = NULL)
 }
 \arguments{
-\item{expr}{The query expression}
+\item{expr}{The query expression. A \code{NULL} expression matches everything.}
 
 \item{name}{Optionally, the name of the packet to scope the query on. This
 will be intersected with \code{scope} arg and is a shorthand way of running

--- a/tests/testthat/test-query-search.R
+++ b/tests/testthat/test-query-search.R
@@ -844,3 +844,16 @@ test_that("allow search before query", {
     ids)
   expect_setequal(names(root$a$index()$metadata), ids)
 })
+
+
+
+test_that("empty search returns full set", {
+  root <- create_temporary_root(use_file_store = TRUE)
+  ids <- list(a = vcapply(1:3, function(i) create_random_packet(root, "a")),
+              b = vcapply(1:3, function(i) create_random_packet(root, "b")))
+
+  expect_equal(outpack_search(root = root),
+               c(ids$a, ids$b))
+  expect_equal(outpack_search(name = "a", root = root),
+               c(ids$a))
+})

--- a/tests/testthat/test-query.R
+++ b/tests/testthat/test-query.R
@@ -12,8 +12,23 @@ test_that("Parse basic query", {
 })
 
 
+test_that("empty query is possible", {
+  expect_equal(
+    query_parse(NULL, NULL, new.env(parent = emptyenv())),
+    query_component("empty", expr = NULL, context = NULL, args = list()))
+  expect_equal(
+    outpack_query(NULL),
+    structure(
+      list(value = query_parse(NULL, NULL, new.env(parent = emptyenv())),
+           subquery = list(),
+           info = list(single = FALSE,
+                       parameters = character())),
+      class = "outpack_query"))
+})
+
+
 test_that("Prevent unparseable queries", {
-  expect_error(query_parse(NULL, NULL, emptyenv()),
+  expect_error(query_parse(1, NULL, emptyenv()),
                "Invalid input for query")
   expect_error(query_parse("latest(); latest()", NULL, emptyenv()),
                "Expected a single expression")


### PR DESCRIPTION
This is required to allow:

```
orderly2::orderly_search(name = "foo")
```

to do the same thing as:

```
orderly2::orderly_search(quote(name == "foo"))
```

which feels desirable (it certainly did while writing the docs!)