### PR TITLE
Fix logging schema

### DIFF
--- a/inst/outpack/schema/config.json
+++ b/inst/outpack/schema/config.json
@@ -31,13 +31,14 @@
         "logging": {
             "type": "object",
             "properties": {
-                "log_level": {
-                    "type": "integer"
+                "threshold": {
+                    "enum": ["info", "debug", "trace"]
                 },
                 "console": {
                     "type": "boolean"
                 }
-            }
+            },
+            "required": ["threshold", "console"]
         },
 
         "location": {


### PR DESCRIPTION
This PR updates the incorrect configuration schema for logging:

* use `threshold`, not `log_level` (the former is the level we filter logs down to, the latter is the level they are emitted with), and correct the type (was integer, should be an enum)
* make `threshold` and `console` required properties if either a `logging` element is present