### PR TITLE
Add simple string interpolation for file from/to renaming

### DIFF
--- a/R/metadata.R
+++ b/R/metadata.R
@@ -261,6 +261,7 @@ orderly_dependency <- function(name, query, use) {
   search_options <- as_outpack_search_options(ctx$search_options)
   if (ctx$is_active) {
     outpack_packet_use_dependency(ctx$packet, query, use,
+                                  envir = ctx$env,
                                   search_options = search_options,
                                   envir = ctx$env,
                                   overwrite = TRUE)
@@ -272,6 +273,7 @@ orderly_dependency <- function(name, query, use) {
     outpack_copy_files(id, use, ctx$path,
                        allow_remote = search_options$allow_remote,
                        overwrite = TRUE,
+                       envir = ctx$env,
                        root = ctx$root)
   }
 

--- a/R/metadata.R
+++ b/R/metadata.R
@@ -241,19 +241,13 @@ static_orderly_artefact <- function(args) {
 ##'   the string `latest`, indicating the most recent version. You may
 ##'   want a more complex query here though.
 ##'
-##' @param use A named character vector of filenames to copy from the
-##'   upstream packet. The name corresponds to the destination name,
-##'   so c(here.csv = "there.csv") will take the upstream file
-##'   `there.csv` and copy it over as `here.csv`.
+##' @param use See [outpack_packet_use_dependency]'s `file` argument
 ##'
 ##' @return Undefined
 ##' @export
 orderly_dependency <- function(name, query, use) {
   assert_scalar_character(name)
   assert_scalar_character(query)
-
-  assert_character(use)
-  assert_named(use, unique = TRUE)
 
   ctx <- orderly_context()
   subquery <- NULL
@@ -287,6 +281,9 @@ static_orderly_dependency <- function(args) {
   use <- args$use
 
   name <- static_string(name)
+
+  ## TODO: this is no longer ok, it might not easily be computable
+  ## really; see mrc-4398
   use <- static_character_vector(use)
   ## TODO: allow passing expressions directly in, that will be much
   ## nicer, but possibly needs some care as we do want a consistent

--- a/R/metadata.R
+++ b/R/metadata.R
@@ -241,7 +241,10 @@ static_orderly_artefact <- function(args) {
 ##'   the string `latest`, indicating the most recent version. You may
 ##'   want a more complex query here though.
 ##'
-##' @param use See [outpack_packet_use_dependency]'s `file` argument
+##' @param use Files to use from the packet found by `query`, usually
+##'   as a named character vector with string interpolation in the
+##'   names; see [orderly2::outpack_packet_use_dependency]'s `file`
+##'   argument for details.
 ##'
 ##' @return Undefined
 ##' @export

--- a/R/metadata.R
+++ b/R/metadata.R
@@ -258,7 +258,6 @@ orderly_dependency <- function(name, query, use) {
   search_options <- as_outpack_search_options(ctx$search_options)
   if (ctx$is_active) {
     outpack_packet_use_dependency(ctx$packet, query, use,
-                                  envir = ctx$env,
                                   search_options = search_options,
                                   envir = ctx$env,
                                   overwrite = TRUE)

--- a/R/outpack_helpers.R
+++ b/R/outpack_helpers.R
@@ -39,16 +39,22 @@
 ##'   though associated with no packet so that it is subject to
 ##'   garbage collection (once we write support for that).
 ##'
+##' @param envir An environment into which string interpolation
+##'   may happen (TODO: docs!). The default here is to use the calling
+##'   environment, whcih is typically reasonableb, but may need
+##'   changing in programmatic use.
+##'
 ##' @return Nothing, invisibly. Primarily called for its side effect
 ##'   of copying files from a packet into the directory `dest`
 ##'
 ##' @export
 outpack_copy_files <- function(id, files, dest, allow_remote = FALSE,
-                               overwrite = TRUE, root = NULL) {
+                               overwrite = TRUE, envir = parent.frame(),
+                               root = NULL) {
   root <- outpack_root_open(root, locate = TRUE)
 
-  assert_named(files, unique = TRUE)
-  plan <- plan_copy_files(root, id, unname(files), names(files))
+  files <- validate_file_from_to(files, envir)
+  plan <- plan_copy_files(root, id, files$from, files$to)
 
   tryCatch(
     file_export(root, id, plan$there, plan$here, dest, overwrite),

--- a/R/outpack_helpers.R
+++ b/R/outpack_helpers.R
@@ -39,10 +39,11 @@
 ##'   though associated with no packet so that it is subject to
 ##'   garbage collection (once we write support for that).
 ##'
-##' @param envir An environment into which string interpolation
-##'   may happen (TODO: docs!). The default here is to use the calling
-##'   environment, whcih is typically reasonableb, but may need
-##'   changing in programmatic use.
+##' @param envir An environment into which string interpolation may
+##'   happen (see [orderly2::outpack_packet_use_dependency] for
+##'   details on the string interpolation).  The default here is to
+##'   use the calling environment, whcih is typically reasonable, but
+##'   may need changing in programmatic use.
 ##'
 ##' @return Nothing, invisibly. Primarily called for its side effect
 ##'   of copying files from a packet into the directory `dest`

--- a/R/outpack_helpers.R
+++ b/R/outpack_helpers.R
@@ -42,7 +42,7 @@
 ##' @param envir An environment into which string interpolation may
 ##'   happen (see [orderly2::outpack_packet_use_dependency] for
 ##'   details on the string interpolation).  The default here is to
-##'   use the calling environment, whcih is typically reasonable, but
+##'   use the calling environment, which is typically reasonable, but
 ##'   may need changing in programmatic use.
 ##'
 ##' @return Nothing, invisibly. Primarily called for its side effect

--- a/R/outpack_misc.R
+++ b/R/outpack_misc.R
@@ -100,16 +100,22 @@ validate_file_from_to <- function(x, environment,
       to[i] <- from[i]
     }
   } else {
-    cli::cli_abort(c(
-      sprintf("Unexpected object type for '%s'", name),
-      x = sprintf("Given object of class %s", collapseq(class(x))),
-      i = "Expected a (named) character vector"))
+    cli::cli_abort(
+      c(sprintf("Unexpected object type for '%s'", name),
+        x = sprintf("Given object of class %s", collapseq(class(x))),
+        i = "Expected a (named) character vector"),
+      call = call)
   }
 
   to_value <- string_interpolate_simple(to, environment, call)
 
-  ## TODO: disallow duplicates
-  ## TODO: disallow interpolation in from
-  ## TODO: do we cope with trailing slashes in to?
+  if (any(duplicated(to_value))) {
+    dups <- unique(to_value[duplicated(to_value)])
+    cli::cli_abort(
+      c(sprintf("Every destination filename (in '%s') must be unique", name),
+        i = sprintf("Duplicate names: %s", collapseq(dups))),
+      call = call)
+  }
+
   data_frame(from = from, to = to_value)
 }

--- a/R/outpack_misc.R
+++ b/R/outpack_misc.R
@@ -102,7 +102,7 @@ validate_file_from_to <- function(x, environment,
   } else {
     cli::cli_abort(c(
       sprintf("Unexpected object type for '%s'", name),
-      x = sprintf("Given object of class %s", collapseq(names(x))),
+      x = sprintf("Given object of class %s", collapseq(class(x))),
       i = "Expected a (named) character vector"))
   }
 

--- a/R/outpack_misc.R
+++ b/R/outpack_misc.R
@@ -106,7 +106,7 @@ validate_file_from_to <- function(x, environment,
       err <- sprintf(
         "If a 'data.frame' is given for '%s' its names must be 'from' and 'to'",
         name)
-      hint <- sprintf("Names of '%s': %s", paste(squote(nms, collapse = ", ")))
+      hint <- sprintf("Names of '%s': %s", collapseq(nms))
       cli::cli_abort(c(err, i = hint))
     }
     ## Cope with missing values here?

--- a/R/outpack_misc.R
+++ b/R/outpack_misc.R
@@ -98,7 +98,9 @@ validate_file_from_to <- function(x, environment,
     if (any(i <- !nzchar(to))) {
       to[i] <- from[i]
     }
-  } else if (inherits(x, c("data_frame", "tbl"))) {
+  } else if (inherits(x, "data.frame")) {
+    ## tbl_df (from tibble/dplyr) and data.table both inherit from
+    ## data.frame here so this will work.
     nms <- names(x)
     if (!setequal(nms, c("from", "to"))) {
       err <- sprintf(
@@ -107,6 +109,7 @@ validate_file_from_to <- function(x, environment,
       hint <- sprintf("Names of '%s': %s", paste(squote(nms, collapse = ", ")))
       cli::cli_abort(c(err, i = hint))
     }
+    ## Cope with missing values here?
   } else {
     cli::cli_abort(c(
       sprintf("Unexpected object type for '%s'", name),
@@ -114,6 +117,10 @@ validate_file_from_to <- function(x, environment,
       i = "Expected a (named) character vector or 'data.frame' / 'tbl_df'"))
   }
 
-  data_frame(from = from,
-             to = string_interpolate_simple(to, environment, call))
+  to_value <- string_interpolate_simple(to, environment, call)
+
+  ## TODO: disallow duplicates
+  ## TODO: disallow interpolation in from
+  ## TODO: do we cope with trailing slashes in to?
+  data_frame(from = from, to = to_value)
 }

--- a/R/outpack_misc.R
+++ b/R/outpack_misc.R
@@ -92,29 +92,18 @@ validate_parameters <- function(parameters) {
 validate_file_from_to <- function(x, environment,
                                   name = deparse(substitute(x)),
                                   call = NULL) {
+  ## Later, we can expand this to support a data.frame too perhaps?
   if (is.character(x)) {
     to <- names(x) %||% x
     from <- unname(x)
     if (any(i <- !nzchar(to))) {
       to[i] <- from[i]
     }
-  } else if (inherits(x, "data.frame")) {
-    ## tbl_df (from tibble/dplyr) and data.table both inherit from
-    ## data.frame here so this will work.
-    nms <- names(x)
-    if (!setequal(nms, c("from", "to"))) {
-      err <- sprintf(
-        "If a 'data.frame' is given for '%s' its names must be 'from' and 'to'",
-        name)
-      hint <- sprintf("Names of '%s': %s", collapseq(nms))
-      cli::cli_abort(c(err, i = hint))
-    }
-    ## Cope with missing values here?
   } else {
     cli::cli_abort(c(
       sprintf("Unexpected object type for '%s'", name),
       x = sprintf("Given object of class %s", collapseq(names(x))),
-      i = "Expected a (named) character vector or 'data.frame' / 'tbl_df'"))
+      i = "Expected a (named) character vector"))
   }
 
   to_value <- string_interpolate_simple(to, environment, call)

--- a/R/outpack_misc.R
+++ b/R/outpack_misc.R
@@ -87,3 +87,33 @@ validate_parameters <- function(parameters) {
                  paste(squote(names(parameters)[!ok]), collapse = ", ")))
   }
 }
+
+
+validate_file_from_to <- function(x, environment,
+                                  name = deparse(substitute(x)),
+                                  call = NULL) {
+  if (is.character(x)) {
+    to <- names(x) %||% x
+    from <- unname(x)
+    if (any(i <- !nzchar(to))) {
+      to[i] <- from[i]
+    }
+  } else if (inherits(x, c("data_frame", "tbl"))) {
+    nms <- names(x)
+    if (!setequal(nms, c("from", "to"))) {
+      err <- sprintf(
+        "If a 'data.frame' is given for '%s' its names must be 'from' and 'to'",
+        name)
+      hint <- sprintf("Names of '%s': %s", paste(squote(nms, collapse = ", ")))
+      cli::cli_abort(c(err, i = hint))
+    }
+  } else {
+    cli::cli_abort(c(
+      sprintf("Unexpected object type for '%s'", name),
+      x = sprintf("Given object of class %s", collapseq(names(x))),
+      i = "Expected a (named) character vector or 'data.frame' / 'tbl_df'"))
+  }
+
+  data_frame(from = from,
+             to = string_interpolate_simple(to, environment, call))
+}

--- a/R/outpack_packet.R
+++ b/R/outpack_packet.R
@@ -263,18 +263,19 @@ outpack_packet_run <- function(packet, script, envir = .GlobalEnv) {
 ##' @param search_options Optional search options for restricting the
 ##'   search (see [orderly2::outpack_search] for details)
 ##'
-##' @param envir Optional environment for `environment:` lookups; the
-##'   default is to use the parent frame, but other suitable options
-##'   are the global environment or the environment of the script you
-##'   are running (this only relevant if you have `environment:`
-##'   lookups in `query`).
+##' @param envir Optional environment for `environment:` lookups in
+##'   `query`, and for interpolating filenames in `files; the default
+##'   is to use the parent frame, but other suitable options are the
+##'   global environment or the environment of the script you are
+##'   running (this only relevant if you have `environment:` lookups
+##'   in `query`).
 ##'
 ##' @param overwrite Overwrite files at the destination; this is
 ##'   typically what you want, but set to `FALSE` if you would prefer
 ##'   that an error be thrown if the destination file already exists.
 outpack_packet_use_dependency <- function(packet, query, files,
-                                          search_options = NULL,
                                           envir = parent.frame(),
+                                          search_options = NULL,
                                           overwrite = TRUE) {
   packet <- check_current_packet(packet)
   query <- as_outpack_query(query)
@@ -314,6 +315,7 @@ outpack_packet_use_dependency <- function(packet, query, files,
   result <- outpack_copy_files(id, files, packet$path,
                                allow_remote = search_options$allow_remote,
                                overwrite = overwrite,
+                               envir = envir,
                                root = packet$root)
 
   query_str <- deparse_query(query$value$expr,

--- a/R/outpack_packet.R
+++ b/R/outpack_packet.R
@@ -282,7 +282,7 @@ outpack_packet_run <- function(packet, script, envir = .GlobalEnv) {
 ##'   search (see [orderly2::outpack_search] for details)
 ##'
 ##' @param envir Optional environment for `environment:` lookups in
-##'   `query`, and for interpolating filenames in `files; the default
+##'   `query`, and for interpolating filenames in `files`; the default
 ##'   is to use the parent frame, but other suitable options are the
 ##'   global environment or the environment of the script you are
 ##'   running (this only relevant if you have `environment:` lookups

--- a/R/outpack_packet.R
+++ b/R/outpack_packet.R
@@ -267,12 +267,16 @@ outpack_packet_run <- function(packet, script, envir = .GlobalEnv) {
 ##'   intended.
 ##'
 ##' You can use a limited form of string interpolation in the names of
-##'   this argument (or its `to` column if using a `data.frame`);
-##'   using `${variable}` will pick up values from `envir` and
-##'   substitute them into your string.  This is similar to the
-##'   interpolation you might be familiar with from `glue::glue` or
-##'   similar, but much simpler with no concatenation or other fancy
-##'   features supported.
+##'   this argument; using `${variable}` will pick up values from
+##'   `envir` and substitute them into your string.  This is similar
+##'   to the interpolation you might be familiar with from
+##'   `glue::glue` or similar, but much simpler with no concatenation
+##'   or other fancy features supported.
+##'
+##' Note that there is an unfortunate, but (to us) avoidable
+##'   inconsistency here; interpolation of values from your
+##'   environment in the query is done by using `environment:x` and in
+##'   the destination filename by doing `${x}`.
 ##'
 ##' @param search_options Optional search options for restricting the
 ##'   search (see [orderly2::outpack_search] for details)

--- a/R/outpack_packet.R
+++ b/R/outpack_packet.R
@@ -250,15 +250,25 @@ outpack_packet_run <- function(packet, script, envir = .GlobalEnv) {
 ##' @param query An [orderly2::outpack_query] object, or something
 ##'   (e.g., a string) that can be trivially converted into one.
 ##'
-##' @param files A named character vector of files; the name
-##'   corresponds to the name within the current packet, while the
-##'   value corresponds to the name within the upstream packet. If you
-##'   want to import a directory of files from a packet, you must
-##'   refer to the source with a trailing slash (e.g., `c(here =
-##'   "there/")`), which will create the local directory `here/...`
-##'   with files from the upstream packet directory `there/`. If you
-##'   omit the slash then an error will be thrown suggesting that you
-##'   add a slash if this is what you intended.
+##' @param files Files to copy from the other packet. This can be (1)
+##'   a character vector, in which case files are copied over without
+##'   changing their names, (2) a **named** character vector, in which
+##'   case the name will be used as the destination name, or (3) a
+##'   [data.frame] (including `tbl_df`, or `data.frame` objects)
+##'   containing columns `from` and `to`, in which case the files
+##'   `from` will be copied with names `to`.
+##'
+##' In all cases, if you want to import a directory of files from a
+##'   packet, you must refer to the source with a trailing slash
+##'   (e.g., `c(here = "there/")`), which will create the local
+##'   directory `here/...` with files from the upstream packet
+##'   directory `there/`. If you omit the slash then an error will be
+##'   thrown suggesting that you add a slash if this is what you
+##'   intended.
+##'
+##' You can use a limited form of string interpolation in the names of
+##'   this argument (or its `to` column if using a `data.frame`);
+##'   using `${variable}` will
 ##'
 ##' @param search_options Optional search options for restricting the
 ##'   search (see [orderly2::outpack_search] for details)

--- a/R/outpack_packet.R
+++ b/R/outpack_packet.R
@@ -268,7 +268,11 @@ outpack_packet_run <- function(packet, script, envir = .GlobalEnv) {
 ##'
 ##' You can use a limited form of string interpolation in the names of
 ##'   this argument (or its `to` column if using a `data.frame`);
-##'   using `${variable}` will
+##'   using `${variable}` will pick up values from `envir` and
+##'   substitute them into your string.  This is similar to the
+##'   interpolation you might be familiar with from `glue::glue` or
+##'   similar, but much simpler with no concatenation or other fancy
+##'   features supported.
 ##'
 ##' @param search_options Optional search options for restricting the
 ##'   search (see [orderly2::outpack_search] for details)

--- a/R/util.R
+++ b/R/util.R
@@ -390,6 +390,11 @@ check_symbol_from_str <- function(str, name) {
 }
 
 
+collapseq <- function(x) {
+  paste(squote(x), collapse = ", ")
+}
+
+
 ## There are so many ways of doing this, none of them are amazing; I
 ## don't really want to use glue for this because it implies we can do
 ## all the things that glue does within the string substitution, which

--- a/R/util.R
+++ b/R/util.R
@@ -390,11 +390,6 @@ check_symbol_from_str <- function(str, name) {
 }
 
 
-collapseq <- function(x) {
-  paste(squote(x), collapse = ", ")
-}
-
-
 ## There are so many ways of doing this, none of them are amazing; I
 ## don't really want to use glue for this because it implies we can do
 ## all the things that glue does within the string substitution, which

--- a/man/orderly_dependency.Rd
+++ b/man/orderly_dependency.Rd
@@ -13,10 +13,7 @@ orderly_dependency(name, query, use)
 the string \code{latest}, indicating the most recent version. You may
 want a more complex query here though.}
 
-\item{use}{A named character vector of filenames to copy from the
-upstream packet. The name corresponds to the destination name,
-so c(here.csv = "there.csv") will take the upstream file
-\code{there.csv} and copy it over as \code{here.csv}.}
+\item{use}{See \link{outpack_packet_use_dependency}'s \code{file} argument}
 }
 \value{
 Undefined

--- a/man/orderly_dependency.Rd
+++ b/man/orderly_dependency.Rd
@@ -13,7 +13,10 @@ orderly_dependency(name, query, use)
 the string \code{latest}, indicating the most recent version. You may
 want a more complex query here though.}
 
-\item{use}{See \link{outpack_packet_use_dependency}'s \code{file} argument}
+\item{use}{Files to use from the packet found by \code{query}, usually
+as a named character vector with string interpolation in the
+names; see \link{outpack_packet_use_dependency}'s \code{file}
+argument for details.}
 }
 \value{
 Undefined

--- a/man/outpack_copy_files.Rd
+++ b/man/outpack_copy_files.Rd
@@ -18,14 +18,25 @@ outpack_copy_files(
 \item{id}{Optionally, an outpack id via \link{outpack_id}. If
 not given a new id will be generated.}
 
-\item{files}{A named character vector of files; the name
-corresponds to the name within the current packet, while the
-value corresponds to the name within the upstream packet. If you
-want to import a directory of files from a packet, you must
-refer to the source with a trailing slash (e.g., \code{c(here = "there/")}), which will create the local directory \code{here/...}
-with files from the upstream packet directory \verb{there/}. If you
-omit the slash then an error will be thrown suggesting that you
-add a slash if this is what you intended.}
+\item{files}{Files to copy from the other packet. This can be (1)
+a character vector, in which case files are copied over without
+changing their names, (2) a \strong{named} character vector, in which
+case the name will be used as the destination name, or (3) a
+\link{data.frame} (including \code{tbl_df}, or \code{data.frame} objects)
+containing columns \code{from} and \code{to}, in which case the files
+\code{from} will be copied with names \code{to}.
+
+In all cases, if you want to import a directory of files from a
+packet, you must refer to the source with a trailing slash
+(e.g., \code{c(here = "there/")}), which will create the local
+directory \code{here/...} with files from the upstream packet
+directory \verb{there/}. If you omit the slash then an error will be
+thrown suggesting that you add a slash if this is what you
+intended.
+
+You can use a limited form of string interpolation in the names of
+this argument (or its \code{to} column if using a \code{data.frame});
+using \verb{$\{variable\}} will}
 
 \item{dest}{The directory to copy into}
 

--- a/man/outpack_copy_files.Rd
+++ b/man/outpack_copy_files.Rd
@@ -35,12 +35,16 @@ thrown suggesting that you add a slash if this is what you
 intended.
 
 You can use a limited form of string interpolation in the names of
-this argument (or its \code{to} column if using a \code{data.frame});
-using \verb{$\{variable\}} will pick up values from \code{envir} and
-substitute them into your string.  This is similar to the
-interpolation you might be familiar with from \code{glue::glue} or
-similar, but much simpler with no concatenation or other fancy
-features supported.}
+this argument; using \verb{$\{variable\}} will pick up values from
+\code{envir} and substitute them into your string.  This is similar
+to the interpolation you might be familiar with from
+\code{glue::glue} or similar, but much simpler with no concatenation
+or other fancy features supported.
+
+Note that there is an unfortunate, but (to us) avoidable
+inconsistency here; interpolation of values from your
+environment in the query is done by using \code{environment:x} and in
+the destination filename by doing \verb{$\{x\}}.}
 
 \item{dest}{The directory to copy into}
 
@@ -59,7 +63,7 @@ that an error be thrown if the destination file already exists.}
 \item{envir}{An environment into which string interpolation may
 happen (see \link{outpack_packet_use_dependency} for
 details on the string interpolation).  The default here is to
-use the calling environment, whcih is typically reasonable, but
+use the calling environment, which is typically reasonable, but
 may need changing in programmatic use.}
 
 \item{root}{The outpack root. Will be searched for from the

--- a/man/outpack_copy_files.Rd
+++ b/man/outpack_copy_files.Rd
@@ -10,6 +10,7 @@ outpack_copy_files(
   dest,
   allow_remote = FALSE,
   overwrite = TRUE,
+  envir = parent.frame(),
   root = NULL
 )
 }
@@ -39,6 +40,11 @@ garbage collection (once we write support for that).}
 \item{overwrite}{Overwrite files at the destination; this is
 typically what you want, but set to \code{FALSE} if you would prefer
 that an error be thrown if the destination file already exists.}
+
+\item{envir}{An environment into which string interpolation
+may happen (TODO: docs!). The default here is to use the calling
+environment, whcih is typically reasonableb, but may need
+changing in programmatic use.}
 
 \item{root}{The outpack root. Will be searched for from the
 current directory if not given.}

--- a/man/outpack_copy_files.Rd
+++ b/man/outpack_copy_files.Rd
@@ -36,7 +36,11 @@ intended.
 
 You can use a limited form of string interpolation in the names of
 this argument (or its \code{to} column if using a \code{data.frame});
-using \verb{$\{variable\}} will}
+using \verb{$\{variable\}} will pick up values from \code{envir} and
+substitute them into your string.  This is similar to the
+interpolation you might be familiar with from \code{glue::glue} or
+similar, but much simpler with no concatenation or other fancy
+features supported.}
 
 \item{dest}{The directory to copy into}
 
@@ -52,10 +56,11 @@ garbage collection (once we write support for that).}
 typically what you want, but set to \code{FALSE} if you would prefer
 that an error be thrown if the destination file already exists.}
 
-\item{envir}{An environment into which string interpolation
-may happen (TODO: docs!). The default here is to use the calling
-environment, whcih is typically reasonableb, but may need
-changing in programmatic use.}
+\item{envir}{An environment into which string interpolation may
+happen (see \link{outpack_packet_use_dependency} for
+details on the string interpolation).  The default here is to
+use the calling environment, whcih is typically reasonable, but
+may need changing in programmatic use.}
 
 \item{root}{The outpack root. Will be searched for from the
 current directory if not given.}

--- a/man/outpack_packet.Rd
+++ b/man/outpack_packet.Rd
@@ -29,8 +29,8 @@ outpack_packet_use_dependency(
   packet,
   query,
   files,
-  search_options = NULL,
   envir = parent.frame(),
+  search_options = NULL,
   overwrite = TRUE
 )
 
@@ -79,11 +79,8 @@ marked immutable have not been changed)}
 relative path).  This function can be safely called multiple
 times within a single packet run (or zero times!) as needed.}
 
-\item{envir}{Optional environment for \verb{environment:} lookups; the
-default is to use the parent frame, but other suitable options
-are the global environment or the environment of the script you
-are running (this only relevant if you have \verb{environment:}
-lookups in \code{query}).}
+\item{envir}{Optional environment for \verb{environment:} lookups in
+\code{query}, and for interpolating filenames in \verb{files; the default is to use the parent frame, but other suitable options are the global environment or the environment of the script you are running (this only relevant if you have }environment:\verb{lookups in}query`).}
 
 \item{query}{An \link{outpack_query} object, or something
 (e.g., a string) that can be trivially converted into one.}

--- a/man/outpack_packet.Rd
+++ b/man/outpack_packet.Rd
@@ -102,12 +102,16 @@ thrown suggesting that you add a slash if this is what you
 intended.
 
 You can use a limited form of string interpolation in the names of
-this argument (or its \code{to} column if using a \code{data.frame});
-using \verb{$\{variable\}} will pick up values from \code{envir} and
-substitute them into your string.  This is similar to the
-interpolation you might be familiar with from \code{glue::glue} or
-similar, but much simpler with no concatenation or other fancy
-features supported.}
+this argument; using \verb{$\{variable\}} will pick up values from
+\code{envir} and substitute them into your string.  This is similar
+to the interpolation you might be familiar with from
+\code{glue::glue} or similar, but much simpler with no concatenation
+or other fancy features supported.
+
+Note that there is an unfortunate, but (to us) avoidable
+inconsistency here; interpolation of values from your
+environment in the query is done by using \code{environment:x} and in
+the destination filename by doing \verb{$\{x\}}.}
 
 \item{search_options}{Optional search options for restricting the
 search (see \link{outpack_search} for details)}

--- a/man/outpack_packet.Rd
+++ b/man/outpack_packet.Rd
@@ -80,7 +80,11 @@ relative path).  This function can be safely called multiple
 times within a single packet run (or zero times!) as needed.}
 
 \item{envir}{Optional environment for \verb{environment:} lookups in
-\code{query}, and for interpolating filenames in \verb{files; the default is to use the parent frame, but other suitable options are the global environment or the environment of the script you are running (this only relevant if you have }environment:\verb{lookups in}query`).}
+\code{query}, and for interpolating filenames in \code{files}; the default
+is to use the parent frame, but other suitable options are the
+global environment or the environment of the script you are
+running (this only relevant if you have \verb{environment:} lookups
+in \code{query}).}
 
 \item{query}{An \link{outpack_query} object, or something
 (e.g., a string) that can be trivially converted into one.}

--- a/man/outpack_packet.Rd
+++ b/man/outpack_packet.Rd
@@ -85,14 +85,25 @@ times within a single packet run (or zero times!) as needed.}
 \item{query}{An \link{outpack_query} object, or something
 (e.g., a string) that can be trivially converted into one.}
 
-\item{files}{A named character vector of files; the name
-corresponds to the name within the current packet, while the
-value corresponds to the name within the upstream packet. If you
-want to import a directory of files from a packet, you must
-refer to the source with a trailing slash (e.g., \code{c(here = "there/")}), which will create the local directory \code{here/...}
-with files from the upstream packet directory \verb{there/}. If you
-omit the slash then an error will be thrown suggesting that you
-add a slash if this is what you intended.}
+\item{files}{Files to copy from the other packet. This can be (1)
+a character vector, in which case files are copied over without
+changing their names, (2) a \strong{named} character vector, in which
+case the name will be used as the destination name, or (3) a
+\link{data.frame} (including \code{tbl_df}, or \code{data.frame} objects)
+containing columns \code{from} and \code{to}, in which case the files
+\code{from} will be copied with names \code{to}.
+
+In all cases, if you want to import a directory of files from a
+packet, you must refer to the source with a trailing slash
+(e.g., \code{c(here = "there/")}), which will create the local
+directory \code{here/...} with files from the upstream packet
+directory \verb{there/}. If you omit the slash then an error will be
+thrown suggesting that you add a slash if this is what you
+intended.
+
+You can use a limited form of string interpolation in the names of
+this argument (or its \code{to} column if using a \code{data.frame});
+using \verb{$\{variable\}} will}
 
 \item{search_options}{Optional search options for restricting the
 search (see \link{outpack_search} for details)}

--- a/man/outpack_packet.Rd
+++ b/man/outpack_packet.Rd
@@ -103,7 +103,11 @@ intended.
 
 You can use a limited form of string interpolation in the names of
 this argument (or its \code{to} column if using a \code{data.frame});
-using \verb{$\{variable\}} will}
+using \verb{$\{variable\}} will pick up values from \code{envir} and
+substitute them into your string.  This is similar to the
+interpolation you might be familiar with from \code{glue::glue} or
+similar, but much simpler with no concatenation or other fancy
+features supported.}
 
 \item{search_options}{Optional search options for restricting the
 search (see \link{outpack_search} for details)}

--- a/tests/testthat/test-outpack-helpers.R
+++ b/tests/testthat/test-outpack-helpers.R
@@ -57,3 +57,20 @@ test_that("can copy files from location, using archive", {
   hash <- meta$files$hash[meta$files$path == "data.rds"]
   expect_equal(hash_file(file.path(tmp, "data.rds"), "sha256"), hash)
 })
+
+
+test_that("can interpolate filenames in copy", {
+  root <- create_temporary_root(use_file_store = TRUE)
+  id <- create_random_packet(root)
+  dst <- temp_file()
+  ## Some bindings to force lookup:
+  path <- "a"
+  file <- "b"
+  outpack_copy_files(id, c("${path}/${file}.rds" = "data.rds"),
+                     dst, root = root)
+  expect_equal(dir(dst), "a")
+  expect_equal(dir(file.path(dst, "a")), "b.rds")
+  expect_identical(
+    readRDS(file.path(dst, "a", "b.rds")),
+    readRDS(file.path(root$path, "archive", "data", id, "data.rds")))
+})

--- a/tests/testthat/test-outpack-misc.R
+++ b/tests/testthat/test-outpack-misc.R
@@ -69,3 +69,25 @@ test_that("Can select multiple dependencies at once", {
   expect_equal(find_all_dependencies(c("d", "e", "f"), metadata),
                c("a", "b", "c", "d", "e", "f"))
 })
+
+
+test_that("can validate file renaming inputs", {
+  env <- list2env(list(a = "aaa", b = "bbb"), parent = emptyenv())
+  expect_equal(
+    validate_file_from_to("a", env),
+    data_frame(from = "a", to = "a"))
+  expect_equal(
+    validate_file_from_to(c("a", B = "b"), env),
+    data_frame(from = c("a", "b"), to = c("a", "B")))
+  expect_equal(
+    validate_file_from_to(c("${a}/a" = "a"), env),
+    data_frame(from = "a", to = "aaa/a"))
+
+  err <- expect_error(
+    validate_file_from_to(1, env, "files"),
+    "Unexpected object type for 'files'")
+  expect_equal(
+    err$body,
+    c(x = "Given object of class 'numeric'",
+      i = "Expected a (named) character vector"))
+})

--- a/tests/testthat/test-outpack-misc.R
+++ b/tests/testthat/test-outpack-misc.R
@@ -90,4 +90,13 @@ test_that("can validate file renaming inputs", {
     err$body,
     c(x = "Given object of class 'numeric'",
       i = "Expected a (named) character vector"))
+
+  expect_error(
+    validate_file_from_to(c("a", "a"), env, "files"),
+    "Every destination filename (in 'files') must be unique",
+    fixed = TRUE)
+  expect_error(
+    validate_file_from_to(c("a" = "x", "a" = "y"), env, "files"),
+    "Every destination filename (in 'files') must be unique",
+    fixed = TRUE)
 })

--- a/tests/testthat/test-util.R
+++ b/tests/testthat/test-util.R
@@ -197,6 +197,7 @@ test_that("can perform simple string interpolation", {
                   parent = emptyenv())
 
   expect_equal(string_interpolate_simple("hello", env), "hello")
+  expect_equal(string_interpolate_simple("${hello", env), "${hello")
   expect_equal(string_interpolate_simple("a ${b} c", env),
                "a banana c")
   expect_equal(string_interpolate_simple("a ${b} ${c}", env),

--- a/tests/testthat/test-util.R
+++ b/tests/testthat/test-util.R
@@ -190,3 +190,71 @@ test_that("can check two vars are of same type", {
   expect_false(is_same_type(1, "TRUE"))
   expect_false(is_same_type(TRUE, "TRUE"))
 })
+
+
+test_that("can perform simple string interpolation", {
+  env <- list2env(list(a = 1, b = "banana", c = "carrot"),
+                  parent = emptyenv())
+
+  expect_equal(string_interpolate_simple("hello", env), "hello")
+  expect_equal(string_interpolate_simple("a ${b} c", env),
+               "a banana c")
+  expect_equal(string_interpolate_simple("a ${b} ${c}", env),
+               "a banana carrot")
+  expect_equal(string_interpolate_simple("a ${b} ${ b }", env),
+               "a banana banana")
+
+  expect_equal(string_interpolate_simple(
+    c("${a}/${b}", "${a}/${c}"), env),
+    c("1/banana", "1/carrot"))
+  expect_equal(string_interpolate_simple(
+    I(c("${a}/${b}", "${a}/${c}")), env),
+    I(c("${a}/${b}", "${a}/${c}")))
+})
+
+
+test_that("prevent problematic string interpolations", {
+  env <- list2env(list(a = NULL, b = "${a}", c = letters, d = "${d}", f = args),
+                  parent = emptyenv())
+
+  err <- expect_error(
+    string_interpolate_simple("a/${b}/c", env),
+    "Can't perform recursive string interpolation")
+  expect_equal(
+    err$body,
+    c(x = "Tried to substitute '${b}' to '${a}'",
+      i = "Was interpolating string 'a/${b}/c'",
+      i = "Don't use '${...}' within the values you are substituting to"))
+
+  err <- expect_error(
+    string_interpolate_simple("a/${b}/${d}", env),
+    "Can't perform recursive string interpolation")
+  expect_equal(
+    err$body,
+    c(x = "Tried to substitute '${b}' to '${a}'",
+      x = "Tried to substitute '${d}' to '${d}'",
+      i = "Was interpolating string 'a/${b}/${d}'",
+      i = "Don't use '${...}' within the values you are substituting to"))
+
+  err <- expect_error(
+    string_interpolate_simple("a/${a}", env),
+    "Failed to convert string interpolation variable to string")
+  expect_equal(
+    err$body,
+    c(x = "Failed when retrieving 'a' which has length 0",
+      i = "Was interpolating string 'a/${a}'",
+      i = "All values in ${...} must refer to strings"))
+
+  err <- expect_error(
+    string_interpolate_simple("a/${x}", env),
+    "Failed to find value for 'x'")
+  expect_equal(err$body, c("i" = "Was interpolating string 'a/${x}'"))
+
+  err <- expect_error(
+    string_interpolate_simple("a/${f}", env),
+    "Failed to convert 'f' to character")
+  msg <- tryCatch(as.character(args), error = identity)
+  expect_equal(err$body,
+               c(x = msg$message,
+                 "i" = "Was interpolating string 'a/${f}'"))
+})


### PR DESCRIPTION
This PR probably requires a bit more checking than most of the ones in the current batch.

The idea here is to work well in a loop we need to do something like:

```
for (r in regions) {
  orderly2::orderly_dependency("fits", quote(parameter:region == environment:r), c("fits/${r}.rds" = "fit.rds"))
}
```

The first part of this (the `environment:r` bit) is in #34, but the second part (the string interpolation on the third arg) is done here.

An alternative would be something like:

```
for (r in regions) {
  orderly2::orderly_dependency("fits", quote(parameter:region == environment:r), setNames("fit.rds", sprintf("fits/%s.rds", r)))
}
```

which is (IMO) much uglier and error prone. I did wonder about adding data.frame support too, but removed it eventually to keep this PR simple (see 633c3e7).

I did think about a glue dependency for this bit of interpolation, but that implies we can do way too much, and so in the end I've gone for this bespoke solution. People can always use their own of course.

The docs would be easier to write if we rename `use` to `files` in `orderly_dependency`
