### PR TITLE
Add support for pushing into outpack_server

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -48,7 +48,7 @@ jobs:
       # releases and then we can install and cache against that.
       - name: setup server
         run: |
-          cargo install --git https://github.com/mrc-ide/outpack_server --branch mrc-4364
+          cargo install --git https://github.com/mrc-ide/outpack_server --branch main
 
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:

--- a/.github/workflows/test-coverage.yaml
+++ b/.github/workflows/test-coverage.yaml
@@ -23,7 +23,7 @@ jobs:
 
       - name: setup server
         run: |
-          cargo install --git https://github.com/mrc-ide/outpack_server --branch mrc-4364
+          cargo install --git https://github.com/mrc-ide/outpack_server --branch main
 
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:

--- a/R/location.R
+++ b/R/location.R
@@ -96,6 +96,8 @@ orderly_location_add <- function(name, type, args, priority = 0, root = NULL,
     ## providing the user with anything actionable yet.
     assert_scalar_character(loc$args[[1]]$path, name = "args$path")
     root_open(loc$args[[1]]$path, locate = FALSE, require_orderly = FALSE)
+  } else if (type == "http") {
+    assert_scalar_character(loc$args[[1]]$url, name = "args$url")
   }
 
   config <- root$config

--- a/R/location_http.R
+++ b/R/location_http.R
@@ -52,5 +52,34 @@ orderly_location_http <- R6::R6Class(
           }
           stop(e)
         })
+    },
+
+    list_unknown_packets = function(ids) {
+      body <- to_json(list(ids = ids, unpacked = scalar(TRUE)), NULL)
+      content <- httr::content_type("application/json")
+      res <- private$client$post("/packets/missing", body, content)
+      list_to_character(res$data)
+    },
+
+    list_unknown_files = function(hashes) {
+      body <- to_json(list(hashes = hashes), NULL)
+      res <- private$client$post("/files/missing", body,
+                                 httr::content_type("application/json"))
+      list_to_character(res$data)
+    },
+
+    push_file = function(src, hash) {
+      body <- httr::upload_file(src, "application/octet-stream")
+      res <- private$client$post(sprintf("/file/%s", hash), body)
+      invisible(NULL)
+    },
+
+    push_metadata = function(packet_id, root) {
+      hash <- get_metadata_hash(packet_id, root)
+      path <- file.path(root$path, ".outpack", "metadata", packet_id)
+      meta <- read_string(path)
+      res <- private$client$post(sprintf("/packet/%s", hash), meta,
+                                 httr::content_type("text/plain"))
+      invisible(NULL)
     }
   ))

--- a/R/outpack_http_client.R
+++ b/R/outpack_http_client.R
@@ -14,6 +14,10 @@ outpack_http_client <- R6::R6Class(
 
     get = function(path, ...) {
       http_client_request(httr::GET, self$url, path, ...)
+    },
+
+    post = function(path, body, ...) {
+      http_client_request(httr::POST, self$url, path, body = body, ...)
     }
   ))
 

--- a/R/util.R
+++ b/R/util.R
@@ -228,9 +228,10 @@ system_file <- function(...) {
 
 
 ## Designed for use reading json files as a single string and dropping
-## and trailing whitespace
+## and trailing whitespace. The warn = FALSE arg prevents an annoying
+## warning about a lack of a trailing newline.
 read_string <- function(path) {
-  trimws(paste(readLines(path), collapse = "\n"))
+  trimws(paste(readLines(path, warn = FALSE), collapse = "\n"))
 }
 
 

--- a/tests/testthat/test-zzz-location-http.R
+++ b/tests/testthat/test-zzz-location-http.R
@@ -95,6 +95,7 @@ describe("http location integration tests", {
   })
 
   it("can push into server", {
+    skip_on_os("windows") # mrc-4442
     root_downstream <- create_temporary_root(use_file_store = TRUE)
     ids_downstream <- create_random_packet_chain(root_downstream, 3)
     orderly_location_add("upstream", "http", list(url = url),
@@ -132,6 +133,7 @@ describe("http location integration tests", {
   })
 
   it("throws sensible error if file hash does not match expected", {
+    skip_on_os("windows") # mrc-4442
     loc <- orderly_location_http$new(url)
 
     tmp <- withr::local_tempfile()

--- a/tests/testthat/test-zzz-location-http.R
+++ b/tests/testthat/test-zzz-location-http.R
@@ -97,9 +97,9 @@ describe("http location integration tests", {
   it("can push into server", {
     root_downstream <- create_temporary_root(use_file_store = TRUE)
     ids_downstream <- create_random_packet_chain(root_downstream, 3)
-    outpack_location_add("upstream", "http", list(url = url),
+    orderly_location_add("upstream", "http", list(url = url),
                          root = root_downstream)
-    plan <- outpack_location_push(ids_downstream[[3]], "upstream",
+    plan <- orderly_location_push(ids_downstream[[3]], "upstream",
                                   root = root_downstream)
     expect_setequal(plan$packet_id, ids_downstream)
     idx <- root$index()
@@ -122,7 +122,7 @@ describe("http location integration tests", {
                         "Hash of packet does not match")
 
     ## Then on the method, should return same error here:
-    loc <- outpack_location_http$new(url)
+    loc <- orderly_location_http$new(url)
     mock_get_metadata_hash <- mockery::mock(hash_bad)
     mockery::stub(loc$push_metadata, "get_metadata_hash",
                   mock_get_metadata_hash)
@@ -132,7 +132,7 @@ describe("http location integration tests", {
   })
 
   it("throws sensible error if file hash does not match expected", {
-    loc <- outpack_location_http$new(url)
+    loc <- orderly_location_http$new(url)
 
     tmp <- withr::local_tempfile()
     writeLines("correct", tmp)

--- a/tests/testthat/test-zzz-location-http.R
+++ b/tests/testthat/test-zzz-location-http.R
@@ -84,7 +84,7 @@ describe("http location integration tests", {
     expect_identical(hash_file(res), hash)
   })
 
-  test_that("sensible error if file not found in store", {
+  it("throws sensible error if file not found in store", {
     loc <- orderly_location_http$new(url)
     h <- "md5:c7be9a2c3cd8f71210d9097e128da316"
     dest <- temp_file()
@@ -92,5 +92,18 @@ describe("http location integration tests", {
       loc$fetch_file(h, dest),
       "Hash 'md5:c7be9a2c3cd8f71210d9097e128da316' not found at location")
     expect_false(file.exists(dest))
+  })
+
+  it("can push into server", {
+    url <- "http://localhost:8000"
+    root_downstream <- create_temporary_root(use_file_store = TRUE)
+    ids_downstream <- create_random_packet_chain(root_downstream, 3)
+    outpack_location_add("upstream", "http", list(url = url),
+                         root = root_downstream)
+    plan <- outpack_location_push(ids_downstream[[3]], "upstream",
+                                  root = root_downstream)
+    expect_setequal(plan$packet_id, ids_downstream)
+    idx <- root$index()
+    expect_true(all(ids_downstream %in% names(idx$metadata)))
   })
 })

--- a/tests/testthat/test-zzz-location-http.R
+++ b/tests/testthat/test-zzz-location-http.R
@@ -104,5 +104,6 @@ describe("http location integration tests", {
     expect_setequal(plan$packet_id, ids_downstream)
     idx <- root$index()
     expect_true(all(ids_downstream %in% names(idx$metadata)))
+    expect_true(all(root_downstream$files$list() %in% root$files$list()))
   })
 })

--- a/tests/testthat/test-zzz-location-http.R
+++ b/tests/testthat/test-zzz-location-http.R
@@ -106,4 +106,46 @@ describe("http location integration tests", {
     expect_true(all(ids_downstream %in% names(idx$metadata)))
     expect_true(all(root_downstream$files$list() %in% root$files$list()))
   })
+
+  it("throws sensible error if metadata hash does not match expected", {
+    root_tmp <- create_temporary_root(use_file_store = TRUE)
+    id_tmp <- create_random_packet(root_tmp)
+
+    hash_bad <- hash_data("", "sha256")
+    meta <- read_string(
+      file.path(root_tmp$path, ".outpack", "metadata", id_tmp))
+
+    ## Trigger the error directly:
+    cl <- outpack_http_client$new(url)
+    err <- expect_error(cl$post(sprintf("/packet/%s", hash_bad), meta,
+                                httr::content_type("text/plain")),
+                        "Hash of packet does not match")
+
+    ## Then on the method, should return same error here:
+    loc <- outpack_location_http$new(url)
+    mock_get_metadata_hash <- mockery::mock(hash_bad)
+    mockery::stub(loc$push_metadata, "get_metadata_hash",
+                  mock_get_metadata_hash)
+    expect_error(loc$push_metadata(id_tmp, root_tmp),
+                 err$message,
+                 fixed = TRUE)
+  })
+
+  it("throws sensible error if file hash does not match expected", {
+    loc <- outpack_location_http$new(url)
+
+    tmp <- withr::local_tempfile()
+    writeLines("correct", tmp)
+    hash_correct <- hash_file(tmp, "sha256")
+    writeLines("corrupt", tmp)
+    hash_corrupt <- hash_file(tmp, "sha256")
+
+    ## This error back is not incredible, as it's not clear what is
+    ## expected, but that's something we can imporove on the rust
+    ## front. This should never get surfaced to the user though.
+    expect_error(
+      loc$push_file(tmp, hash_correct),
+      sprintf("Hash %s does not match file contents. Expected %s",
+              hash_correct, hash_corrupt))
+  })
 })

--- a/tests/testthat/test-zzz-location-http.R
+++ b/tests/testthat/test-zzz-location-http.R
@@ -95,7 +95,6 @@ describe("http location integration tests", {
   })
 
   it("can push into server", {
-    url <- "http://localhost:8000"
     root_downstream <- create_temporary_root(use_file_store = TRUE)
     ids_downstream <- create_random_packet_chain(root_downstream, 3)
     outpack_location_add("upstream", "http", list(url = url),


### PR DESCRIPTION
This PR adds support for pushing using the http client.

There is a failure here that comes from outpack_server; the fix will need to be done there but I can't trigger it outside of the action. It's likely that adding tests to the underlying outpack_server PR will surface the issue though.

See https://github.com/mrc-ide/outpack_server/pull/24 for the server side tweaks