### PR TITLE
Interpolate environment values into query

### DIFF
--- a/R/metadata.R
+++ b/R/metadata.R
@@ -110,7 +110,7 @@ orderly_description <- function(display = NULL, long = NULL, custom = NULL) {
     assert_named(custom)
     assert_is(custom, "list")
     for (i in names(custom)) {
-      assert_scalar_atomic(custom[[i]], sprintf("custom$%s", i))
+      assert_simple_scalar_atomic(custom[[i]], sprintf("custom$%s", i))
     }
   }
 

--- a/R/outpack_misc.R
+++ b/R/outpack_misc.R
@@ -77,11 +77,7 @@ validate_parameters <- function(parameters) {
   }
   assert_is(parameters, "list")
   assert_named(parameters, unique = TRUE)
-  ## NOTE: technically this allows raw and complex through, which is a
-  ## bit undesirable but unlikely
-  ok <- vlapply(parameters, function(x) {
-    length(x) == 1 && is.atomic(x) && !is.na(x)
-  })
+  ok <- vlapply(parameters, is_simple_scalar_atomic)
   if (!all(ok)) {
     stop(sprintf("All parameters must be scalar atomics: error for %s",
                  paste(squote(names(parameters)[!ok]), collapse = ", ")))

--- a/R/outpack_packet.R
+++ b/R/outpack_packet.R
@@ -302,7 +302,7 @@ outpack_packet_use_dependency <- function(packet, query, files,
   if (!query$info$single) {
     stop(paste(
       "The provided query is not guaranteed to return a single value:",
-      squote(deparse_query(query$value$expr)),
+      squote(deparse_query(query$value$expr, NULL, NULL)),
       "Did you forget latest(...)?"))
   }
 
@@ -337,7 +337,8 @@ outpack_packet_use_dependency <- function(packet, query, files,
                                root = packet$root)
 
   query_str <- deparse_query(query$value$expr,
-                             lapply(query$subquery, "[[", "expr"))
+                             lapply(query$subquery, "[[", "expr"),
+                             envir)
 
   ## Only update packet information after success, to reflect new
   ## metadata

--- a/R/query.R
+++ b/R/query.R
@@ -302,15 +302,15 @@ as_logical <- function(expr) {
 
 query_error <- function(msg, expr, context, prefix) {
   if (identical(expr, context)) {
-    stop(sprintf("%s\n  - %s %s", msg, prefix, deparse_query(expr, NULL)),
+    stop(sprintf("%s\n  - %s %s", msg, prefix, deparse_query(expr, NULL, NULL)),
          call. = FALSE)
   } else {
     width <- max(nchar(prefix), nchar("within"))
     stop(sprintf(
       "%s\n  - %s %s\n  - %s %s",
       msg,
-      format(prefix, width = width), deparse_query(expr, NULL),
-      format("within", width = width), deparse_query(context, NULL)),
+      format(prefix, width = width), deparse_query(expr, NULL, NULL),
+      format("within", width = width), deparse_query(context, NULL, NULL)),
       call. = FALSE)
   }
 }
@@ -334,7 +334,7 @@ query_parse_check_call <- function(expr, context) {
   if (!is.call(expr)) {
     query_parse_error(sprintf(
       "Invalid query '%s'; expected some sort of expression",
-      deparse_query(expr, NULL)),
+      deparse_query(expr, NULL, NULL)),
       expr, context)
   }
 
@@ -356,7 +356,7 @@ query_parse_check_call <- function(expr, context) {
   if (is.null(len)) {
     query_parse_error(sprintf(
       "Invalid query '%s'; unknown query component '%s'",
-      deparse_query(expr, NULL), fn),
+      deparse_query(expr, NULL, NULL), fn),
       expr, context)
   }
 
@@ -400,7 +400,7 @@ query_parse_value <- function(expr, context, subquery_env) {
     list(type = "lookup",
          name = deparse(expr))
   } else if (is_call(expr, ":")) {
-    name <- deparse_query(expr[[2]], NULL)
+    name <- deparse_query(expr[[2]], NULL, NULL)
     valid <- c("parameter", "this", "environment")
     if (!(name %in% valid)) {
         query_parse_error(sprintf(
@@ -408,13 +408,13 @@ query_parse_value <- function(expr, context, subquery_env) {
     }
     list(type = "lookup",
          name = name,
-         query = deparse_query(expr[[3]], NULL),
+         query = deparse_query(expr[[3]], NULL, NULL),
          expr = expr,
          context = context)
   } else {
     query_parse_error(
       sprintf("Unhandled query expression value '%s'",
-              deparse_query(expr, NULL)),
+              deparse_query(expr, NULL, NULL)),
       expr, context)
   }
 }
@@ -439,7 +439,7 @@ make_subquery_env <- function(subquery) {
 add_subquery <- function(name, expr, context, subquery_env) {
   anonymous <- is.null(name)
   if (anonymous) {
-    name <- openssl::md5(deparse_query(expr, NULL))
+    name <- openssl::md5(deparse_query(expr, NULL, NULL))
   }
   subquery_env[[name]] <- list(
     name = name,

--- a/R/query_deparse.R
+++ b/R/query_deparse.R
@@ -8,6 +8,13 @@
 #'   language object).  Note that you must not provide an
 #'   already-deparsed query here or it will get quoted!
 #'
+#' @param envir Optionally an environment of values to substitute in
+#'   for `environment:` lookups; if given, then formatting a query
+#'   will turn something like `latest(parameter:x == environment:a)`
+#'   into `latest(parameter:x == 1)` (if `a` within `envir` is
+#'   1). This can be used to make queries self contained even after
+#'   the environment has gone.
+#'
 #' @return Query expression as a string
 #' @export
 #'
@@ -17,8 +24,13 @@
 #'   quote(usedby({A})),
 #'   subquery = list(A = quote(latest(name == "a"))))
 #'
+#' orderly2::outpack_query_format(
+#'   quote(parameter:x == environment:x))
+#' #' orderly2::outpack_query_format(
+#'   quote(parameter:x == environment:x), envir = list2env(x = 1))
+#'
 #' format(orderly2::outpack_query("latest", name = "a"))
-outpack_query_format <- function(query, subquery = NULL) {
+outpack_query_format <- function(query, subquery = NULL, envir = NULL) {
   if (!is_deparseable_query(query)) {
     stop("Cannot format query, it must be a language object or be length 1.")
   }
@@ -32,13 +44,13 @@ outpack_query_format <- function(query, subquery = NULL) {
     }
   }
 
-  deparse_query(query, subquery)
+  deparse_query(query, subquery, envir)
 }
 
 
 ##' @export
-format.outpack_query <- function(x, ...) {
-  deparse_query(x$value$expr, lapply(x$subquery, "[[", "expr"))
+format.outpack_query <- function(x, envir = NULL, ...) {
+  deparse_query(x$value$expr, lapply(x$subquery, "[[", "expr"), envir)
 }
 
 
@@ -47,7 +59,7 @@ is_deparseable_query <- function(x) {
 }
 
 
-deparse_query <- function(x, subquery) {
+deparse_query <- function(x, subquery, envir) {
   if (length(x) == 1) {
     return(deparse_single(x))
   }
@@ -63,14 +75,14 @@ deparse_query <- function(x, subquery) {
   bracket_operators <- list("(" = ")", "{" = "}", "[" = "]")
 
   if (fn %in% infix_operators && length(args) == 2) {
-    query_str <- deparse_infix(fn, args, subquery)
+    query_str <- deparse_infix(fn, args, subquery, envir)
   } else if (fn %in% prefix_operators) {
-    query_str <- deparse_prefix(fn, args, subquery)
+    query_str <- deparse_prefix(fn, args, subquery, envir)
   } else if (fn %in% names(bracket_operators)) {
     closing <- bracket_operators[[fn]]
-    query_str <- deparse_brackets(fn, args, subquery, closing)
+    query_str <- deparse_brackets(fn, args, subquery, envir, closing)
   } else {
-    query_str <- deparse_regular_function(fn, args, subquery)
+    query_str <- deparse_regular_function(fn, args, subquery, envir)
   }
   query_str
 }
@@ -85,18 +97,25 @@ deparse_single <- function(x) {
   str
 }
 
-deparse_prefix <- function(fn, args, subquery) {
-  deparse_regular_function(fn, args, subquery,
+deparse_prefix <- function(fn, args, subquery, envir) {
+  deparse_regular_function(fn, args, subquery, envir,
                            opening_bracket = "", closing_bracket = "")
 }
 
-deparse_infix <- function(fn, args, subquery) {
+deparse_infix <- function(fn, args, subquery, envir) {
   sep <- if (fn == ":") "" else " "
-  paste(deparse_query(args[[1]], subquery), fn,
-        deparse_query(args[[2]], subquery), sep = sep)
+  lhs <- deparse_query(args[[1]], subquery, envir)
+  rhs <- deparse_query(args[[2]], subquery, envir)
+  if (fn == ":" && identical(lhs, "environment") && is.environment(envir)) {
+    value <- query_eval_lookup_environment(rhs, envir)
+    if (value$found && value$valid) {
+      return(deparse_single(value$value))
+    }
+  }
+  paste(lhs, fn, rhs, sep = sep)
 }
 
-deparse_brackets <- function(fn, args, subquery, closing) {
+deparse_brackets <- function(fn, args, subquery, envir, closing) {
   if (fn == "[") {
     func <- args[[1]]
     args <- args[-1]
@@ -113,11 +132,13 @@ deparse_brackets <- function(fn, args, subquery, closing) {
     }
   }
 
-  deparse_regular_function(func, args, subquery, fn, closing)
+  deparse_regular_function(func, args, subquery, envir, fn, closing)
 }
 
-deparse_regular_function <- function(fn, args, subquery, opening_bracket = "(",
+deparse_regular_function <- function(fn, args, subquery, envir,
+                                     opening_bracket = "(",
                                      closing_bracket = ")") {
-  arg_str <- paste(vcapply(args, deparse_query, subquery), collapse = ", ")
+  arg_str <- paste(vcapply(args, deparse_query, subquery, envir),
+                   collapse = ", ")
   paste0(fn, opening_bracket, arg_str, closing_bracket)
 }

--- a/R/query_deparse.R
+++ b/R/query_deparse.R
@@ -26,8 +26,8 @@
 #'
 #' orderly2::outpack_query_format(
 #'   quote(parameter:x == environment:x))
-#' #' orderly2::outpack_query_format(
-#'   quote(parameter:x == environment:x), envir = list2env(x = 1))
+#' orderly2::outpack_query_format(
+#'   quote(parameter:x == environment:x), envir = list2env(list(x = 1)))
 #'
 #' format(orderly2::outpack_query("latest", name = "a"))
 outpack_query_format <- function(query, subquery = NULL, envir = NULL) {

--- a/R/run.R
+++ b/R/run.R
@@ -293,9 +293,7 @@ check_parameter_values <- function(given, defaults) {
       name, paste(squote(names(nonscalar[nonscalar])), collapse = ", ")))
   }
 
-  err <- !vlapply(given, function(x) {
-    is.character(x) || is.numeric(x) || is.logical(x)
-  })
+  err <- !vlapply(given, is_simple_atomic)
   if (any(err)) {
     stop(sprintf(
       "Invalid %s: %s - must be character, numeric or logical",

--- a/R/util.R
+++ b/R/util.R
@@ -527,3 +527,13 @@ delete_empty_directories <- function(path) {
 with_trailing_slash <- function(x) {
   sub("(?<![/])$", "/", x, perl = TRUE)
 }
+
+
+is_simple_scalar_atomic <- function(x) {
+  length(x) == 1 && is_simple_atomic(x)
+}
+
+
+is_simple_atomic <- function(x) {
+  (is.character(x) || is.numeric(x) || is.logical(x)) && !anyNA(x)
+}

--- a/R/util_assert.R
+++ b/R/util_assert.R
@@ -40,9 +40,9 @@ assert_scalar_logical <- function(x, name = deparse(substitute(x))) {
   assert_logical(x, name)
 }
 
-assert_scalar_atomic <- function(x, name = deparse(substitute(x))) {
+assert_simple_scalar_atomic <- function(x, name = deparse(substitute(x))) {
   assert_scalar(x, name)
-  if (!is.atomic(x)) {
+  if (!is_simple_atomic(x)) {
     stop(sprintf("'%s' must be atomic (string, numeric, logical)", name))
   }
   invisible(x)

--- a/man/outpack_query_format.Rd
+++ b/man/outpack_query_format.Rd
@@ -37,8 +37,8 @@ orderly2::outpack_query_format(
 
 orderly2::outpack_query_format(
   quote(parameter:x == environment:x))
-#' orderly2::outpack_query_format(
-  quote(parameter:x == environment:x), envir = list2env(x = 1))
+orderly2::outpack_query_format(
+  quote(parameter:x == environment:x), envir = list2env(list(x = 1)))
 
 format(orderly2::outpack_query("latest", name = "a"))
 }

--- a/man/outpack_query_format.Rd
+++ b/man/outpack_query_format.Rd
@@ -5,7 +5,7 @@
 \title{Format outpack query for displaying to users. It will typically be
 easier to use the \link{format} method of \code{outpack_query} objects.}
 \usage{
-outpack_query_format(query, subquery = NULL)
+outpack_query_format(query, subquery = NULL, envir = NULL)
 }
 \arguments{
 \item{query}{The outpack query to print}
@@ -14,6 +14,13 @@ outpack_query_format(query, subquery = NULL)
 each must be a valid deparseable subquery (i.e., a literal or
 language object).  Note that you must not provide an
 already-deparsed query here or it will get quoted!}
+
+\item{envir}{Optionally an environment of values to substitute in
+for \verb{environment:} lookups; if given, then formatting a query
+will turn something like \code{latest(parameter:x == environment:a)}
+into \code{latest(parameter:x == 1)} (if \code{a} within \code{envir} is
+1). This can be used to make queries self contained even after
+the environment has gone.}
 }
 \value{
 Query expression as a string
@@ -27,6 +34,11 @@ orderly2::outpack_query_format(quote(name == "example"))
 orderly2::outpack_query_format(
   quote(usedby({A})),
   subquery = list(A = quote(latest(name == "a"))))
+
+orderly2::outpack_query_format(
+  quote(parameter:x == environment:x))
+#' orderly2::outpack_query_format(
+  quote(parameter:x == environment:x), envir = list2env(x = 1))
 
 format(orderly2::outpack_query("latest", name = "a"))
 }

--- a/tests/testthat/test-query-deparse.R
+++ b/tests/testthat/test-query-deparse.R
@@ -99,17 +99,17 @@ test_that("can interpolate environment values back into query", {
   ## No variable found
   expect_equal(
     outpack_query_format(quote(parameter:x == environment:c), envir = env2),
-    'parameter:x == environment:c')
+    "parameter:x == environment:c")
   ## Rejected, is null
   expect_equal(
     outpack_query_format(quote(parameter:x == environment:x), envir = env2),
-    'parameter:x == environment:x')
+    "parameter:x == environment:x")
   ## Rejected, is vector
   expect_equal(
     outpack_query_format(quote(parameter:x == environment:y), envir = env2),
-    'parameter:x == environment:y')
+    "parameter:x == environment:y")
   ## Rejected, is function
   expect_equal(
     outpack_query_format(quote(parameter:x == environment:z), envir = env2),
-    'parameter:x == environment:z')
+    "parameter:x == environment:z")
 })

--- a/tests/testthat/test-query-search.R
+++ b/tests/testthat/test-query-search.R
@@ -125,6 +125,21 @@ test_that("Can filter based on given values", {
            "  - while evaluating this:x\n",
            "  - within           latest(parameter:a == this:x)"),
     fixed = TRUE)
+  env <- list2env(list(a = sum), parent = emptyenv())
+  expect_error(
+    outpack_search(quote(latest(parameter:a == environment:x)),
+                  envir = env, root = root),
+    paste0("Did not find 'x' within given environment (containing 'a')\n",
+           "  - while evaluating environment:x\n",
+           "  - within           latest(parameter:a == environment:x)"),
+    fixed = TRUE)
+  expect_error(
+    outpack_search(quote(latest(parameter:a == environment:a)),
+                  envir = env, root = root),
+    paste0("The value of 'a' from environment is not suitable as a lookup\n",
+           "  - while evaluating environment:a\n",
+           "  - within           latest(parameter:a == environment:a)"),
+    fixed = TRUE)
 })
 
 

--- a/tests/testthat/test-run.R
+++ b/tests/testthat/test-run.R
@@ -824,15 +824,18 @@ test_that("can compute dependencies", {
 
   env2$x <- 3
   id <- orderly_run("use", root = path, envir = env2)
-  expect_equal(outpack_metadata(id, root = path)$depends[[1]], id2)
+  meta <- outpack_metadata(id, root = path)
+  expect_equal(meta$depends$packet, id2)
+  expect_equal(meta$depends$query,
+               'latest(parameter:a == 3 && name == "parameters")')
 
   writeLines(c("x <- 1", code), file.path(path_src, "orderly.R"))
   id <- orderly_run("use", root = path, envir = env2)
-  expect_equal(outpack_metadata(id, root = path)$depends[[1]], id1)
+  expect_equal(outpack_metadata(id, root = path)$depends$packet, id1)
 
   rm(list = "x", envir = env2)
   id <- orderly_run("use", root = path, envir = env2)
-  expect_equal(outpack_metadata(id, root = path)$depends[[1]], id1)
+  expect_equal(outpack_metadata(id, root = path)$depends$packet, id1)
 })
 
 

--- a/tests/testthat/test-util-assert.R
+++ b/tests/testthat/test-util-assert.R
@@ -26,11 +26,11 @@ test_that("assert_logical", {
 })
 
 
-test_that("assert_scalar_atomic", {
-  expect_silent(assert_scalar_atomic(TRUE))
-  expect_silent(assert_scalar_atomic(1))
-  expect_silent(assert_scalar_atomic("a"))
-  expect_error(assert_scalar_atomic(list(1)), "must be atomic")
+test_that("assert_simple_scalar_atomic", {
+  expect_silent(assert_simple_scalar_atomic(TRUE))
+  expect_silent(assert_simple_scalar_atomic(1))
+  expect_silent(assert_simple_scalar_atomic("a"))
+  expect_error(assert_simple_scalar_atomic(list(1)), "must be atomic")
 })
 
 

--- a/tests/testthat/test-util.R
+++ b/tests/testthat/test-util.R
@@ -21,12 +21,12 @@ test_that("drop_null can filter list", {
 })
 
 
-test_that("assert_scalar_atomic rejects non-atomic entries", {
+test_that("assert_simple_scalar_atomic rejects non-atomic entries", {
   value <- list(1)
-  expect_error(assert_scalar_atomic(value),
+  expect_error(assert_simple_scalar_atomic(value),
                "'value' must be atomic (string, numeric, logical)",
                fixed = TRUE)
-  expect_silent(assert_scalar_atomic(1))
+  expect_silent(assert_simple_scalar_atomic(1))
 })
 
 


### PR DESCRIPTION
As discussed yesterday, this PR interpolates the values into `environment:<name>` lookups. At the same time I've snuck in some logic bits that were missing from the environment lookup:

* allow lookup up the environment chain, which is needed if anyone programs against this
* check that the value we find in the environment is actually usable
* pulled the "is a reasonable scalar atomic" check into a reusable function