### PR TITLE
Allow orderly_copy_files to accept a query

### DIFF
--- a/R/cleanup.R
+++ b/R/cleanup.R
@@ -86,7 +86,7 @@ orderly_cleanup_status <- function(name = NULL, root = NULL, locate = TRUE) {
   }
   nms_resource <- info$resources
   nms_artefact <- unlist(lapply(info$artefacts, "[[", "files"))
-  nms_dependency <- unlist(lapply(info$dependency, function(x) names(x$use)))
+  nms_dependency <- unlist(lapply(info$dependency, function(x) names(x$files)))
   nms_shared_resource <- names(info$shared_resource)
 
   role <- cbind(orderly = files == "orderly.R",

--- a/R/metadata.R
+++ b/R/metadata.R
@@ -262,15 +262,9 @@ orderly_dependency <- function(name, query, use) {
                                   envir = ctx$env,
                                   overwrite = TRUE)
   } else {
-    id <- orderly_search(query, parameters = ctx$parameters,
-                         envir = ctx$env,
-                         options = search_options,
-                         root = ctx$root)
-    orderly_copy_files(id, use, ctx$path,
-                       allow_remote = search_options$allow_remote,
-                       overwrite = TRUE,
-                       envir = ctx$env,
-                       root = ctx$root)
+    orderly_copy_files(query, files = use, dest = ctx$path, overwrite = TRUE,
+                       parameters = ctx$parameters, options = search_options,
+                       envir = ctx$env, root = ctx$root)
   }
 
   invisible()

--- a/R/metadata.R
+++ b/R/metadata.R
@@ -241,14 +241,11 @@ static_orderly_artefact <- function(args) {
 ##'   the string `latest`, indicating the most recent version. You may
 ##'   want a more complex query here though.
 ##'
-##' @param use Files to use from the packet found by `query`, usually
-##'   as a named character vector with string interpolation in the
-##'   names; see [orderly2::orderly_copy_files]' `file` argument for
-##'   details.
+##' @inheritParams orderly_copy_files
 ##'
 ##' @return Undefined
 ##' @export
-orderly_dependency <- function(name, query, use) {
+orderly_dependency <- function(name, query, files) {
   assert_scalar_character(name)
   assert_scalar_character(query)
 
@@ -257,12 +254,12 @@ orderly_dependency <- function(name, query, use) {
   query <- orderly_query(query, name = name, subquery = subquery)
   search_options <- as_orderly_search_options(ctx$search_options)
   if (ctx$is_active) {
-    outpack_packet_use_dependency(ctx$packet, query, use,
+    outpack_packet_use_dependency(ctx$packet, query, files,
                                   search_options = search_options,
                                   envir = ctx$env,
                                   overwrite = TRUE)
   } else {
-    orderly_copy_files(query, files = use, dest = ctx$path, overwrite = TRUE,
+    orderly_copy_files(query, files = files, dest = ctx$path, overwrite = TRUE,
                        parameters = ctx$parameters, options = search_options,
                        envir = ctx$env, root = ctx$root)
   }
@@ -274,18 +271,18 @@ orderly_dependency <- function(name, query, use) {
 static_orderly_dependency <- function(args) {
   name <- args$name
   query <- args$query
-  use <- args$use
+  files <- args$files
 
   name <- static_string(name)
-  use <- static_character_vector(use, TRUE)
+  files <- static_character_vector(files, TRUE)
   ## TODO: allow passing expressions directly in, that will be much
   ## nicer, but possibly needs some care as we do want a consistent
   ## approach to NSE here
   query <- static_string(query)
-  if (is.null(name) || is.null(use) || is.null(query)) {
+  if (is.null(name) || is.null(files) || is.null(query)) {
     return(NULL)
   }
-  list(name = name, query = query, use = use)
+  list(name = name, query = query, files = files)
 }
 
 

--- a/R/outpack_helpers.R
+++ b/R/outpack_helpers.R
@@ -73,6 +73,7 @@
 ##'   that an error be thrown if the destination file already exists.
 ##'
 ##' @inheritParams orderly_search
+##' @inheritParams orderly_metadata
 ##'
 ##' @return Nothing, invisibly. Primarily called for its side effect
 ##'   of copying files from a packet into the directory `dest`

--- a/R/outpack_helpers.R
+++ b/R/outpack_helpers.R
@@ -80,7 +80,7 @@
 ##' @export
 orderly_copy_files <- function(..., files, dest, overwrite = TRUE,
                                envir = parent.frame(), options = NULL,
-                               root = NULL) {
+                               root = NULL, locate = TRUE) {
   root <- root_open(root, locate = locate, require_orderly = FALSE,
                     call = environment())
 

--- a/R/outpack_helpers.R
+++ b/R/outpack_helpers.R
@@ -117,7 +117,8 @@ orderly_copy_files <- function(..., files, dest, overwrite = TRUE,
       if (!as_orderly_search_options(options)$allow_remote) {
         stop(paste0(
           "Unable to copy files, as they are not available locally\n",
-          "To fetch from a location, try again with 'allow_remote = TRUE'\n",
+          "To fetch from a location, try again with",
+          "  'options = list(allow_remote = TRUE)'\n",
           "Original error:\n", e$message),
           call. = FALSE)
       }

--- a/R/outpack_helpers.R
+++ b/R/outpack_helpers.R
@@ -2,7 +2,18 @@
 ##' [orderly2::orderly_dependency] except that this is not used in an
 ##' active packet context. You can use this function to pull files
 ##' from an outpack root to a directory outside of the control of
-##' outpack, for example.
+##' outpack, for example. Note that all arguments need must be
+##' provided by name, not position, with the exception of the id or
+##' query.
+##'
+##' You can call this function with an id as a string, in which case
+##' we do not search for the packet and proceed regardless of whether
+##' or not this id is present.  If called with any other arguments
+##' (e.g., a string that does not match the id format, or a named
+##' argument `name`, `subquery` or `parameters`) then we interpret the
+##' arguments as a query and [orderly2::orderly_search] to find the
+##' id. It is an error if this query does not return exactly one
+##' packet id, so you probably want to use `latest()`.
 ##'
 ##' There are different ways that this might fail (or recover from
 ##' failure):
@@ -26,9 +37,6 @@
 ##' Note that empty directories might be created on failure.
 ##'
 ##' @title Copy files from a packet
-##'
-##' @param id Id of the packet to copy from (will become a query, see
-##'   mrc-4418)
 ##'
 ##' @param files Files to copy from the other packet. This can be (1)
 ##'   a character vector, in which case files are copied over without
@@ -60,43 +68,53 @@
 ##'
 ##' @param dest The directory to copy into
 ##'
-##' @param allow_remote Logical, indicating if we should attempt to
-##'   retrieve the file from any remote location if it cannot be found
-##'   locally. If the file is large, this may take some time depending
-##'   on the speed of the connection. If you use a file store, note
-##'   that this does add the downloaded file into your file store,
-##'   though associated with no packet so that it is subject to
-##'   garbage collection (once we write support for that).
-##'
 ##' @param overwrite Overwrite files at the destination; this is
 ##'   typically what you want, but set to `FALSE` if you would prefer
 ##'   that an error be thrown if the destination file already exists.
 ##'
-##' @param envir An environment into which string interpolation may
-##'   happen (see the `files` argument for details on the string
-##'   interpolation).  The default here is to use the calling
-##'   environment, which is typically reasonable, but may need
-##'   changing in programmatic use.
-##'
-##' @inheritParams orderly_metadata
+##' @inheritParams orderly_search
 ##'
 ##' @return Nothing, invisibly. Primarily called for its side effect
 ##'   of copying files from a packet into the directory `dest`
 ##'
 ##' @export
-orderly_copy_files <- function(id, files, dest, allow_remote = FALSE,
-                               overwrite = TRUE, envir = parent.frame(),
-                               root = NULL, locate = TRUE) {
+orderly_copy_files <- function(..., files, dest, overwrite = TRUE,
+                               envir = parent.frame(), options = NULL,
+                               root = NULL) {
   root <- root_open(root, locate = locate, require_orderly = FALSE,
                     call = environment())
 
+  ## Validate files and dest early; it gives a better error where this
+  ## was not provided with names.
   files <- validate_file_from_to(files, envir)
+  assert_scalar_character(dest)
+
+  if (dots_is_literal_id(...)) {
+    id <- ..1
+    if (length(id) != 1) {
+      cli::cli_abort(sprintf(
+        "Expected a length 1 value for first argument if id (not %d)",
+        length(id)))
+    }
+  } else {
+    id <- orderly_search(..., options = options, envir = envir, root = root)
+    if (length(id) > 1) {
+      cli::cli_abort(c(
+        sprintf("Query returned %d results, expected a single result",
+                length(id)),
+        i = "Did you forget latest()?"))
+    }
+    if (length(id) == 0 || is.na(id)) {
+      cli::cli_abort("Query returned 0 results")
+    }
+  }
+
   plan <- plan_copy_files(root, id, files$from, files$to)
 
   tryCatch(
     file_export(root, id, plan$there, plan$here, dest, overwrite),
     not_found_error = function(e) {
-      if (!allow_remote) {
+      if (!as_orderly_search_options(options)$allow_remote) {
         stop(paste0(
           "Unable to copy files, as they are not available locally\n",
           "To fetch from a location, try again with 'allow_remote = TRUE'\n",

--- a/R/outpack_packet.R
+++ b/R/outpack_packet.R
@@ -297,7 +297,7 @@ outpack_packet_use_dependency <- function(packet, query, files,
                                  root = packet$root)
   }
 
-  result <- orderly_copy_files(id, files, packet$path,
+  result <- orderly_copy_files(id, files = files, dest = packet$path,
                                allow_remote = search_options$allow_remote,
                                overwrite = overwrite,
                                envir = envir,

--- a/R/outpack_packet.R
+++ b/R/outpack_packet.R
@@ -298,7 +298,7 @@ outpack_packet_use_dependency <- function(packet, query, files,
   }
 
   result <- orderly_copy_files(id, files = files, dest = packet$path,
-                               allow_remote = search_options$allow_remote,
+                               options = search_options,
                                overwrite = overwrite,
                                envir = envir,
                                root = packet$root)

--- a/R/outpack_tools.R
+++ b/R/outpack_tools.R
@@ -180,9 +180,7 @@ orderly_metadata_extract <- function(..., extract = NULL, root = NULL,
                                      locate = TRUE) {
   root <- root_open(root, locate = locate, require_orderly = FALSE,
                     call = environment())
-  assume_ids <- ...length() == 1 && is.null(...names()) && is.character(..1) &&
-    all(grepl(re_id, ..1))
-  if (assume_ids) {
+  if (dots_is_literal_id(...)) {
     ids <- ..1
   } else {
     ids <- orderly_search(..., root = root)

--- a/R/query.R
+++ b/R/query.R
@@ -49,6 +49,12 @@ orderly_query <- function(expr, name = NULL, scope = NULL, subquery = NULL) {
 }
 
 
+dots_is_literal_id <- function(...) {
+  ...length() == 1 && is.null(...names()) && is.character(..1) &&
+    all(grepl(re_id, ..1))
+}
+
+
 as_orderly_query <- function(expr, ...) {
   if (missing(expr)) {
     expr <- NULL

--- a/man/orderly_copy_files.Rd
+++ b/man/orderly_copy_files.Rd
@@ -5,19 +5,18 @@
 \title{Copy files from a packet}
 \usage{
 orderly_copy_files(
-  id,
+  ...,
   files,
   dest,
-  allow_remote = FALSE,
   overwrite = TRUE,
   envir = parent.frame(),
-  root = NULL,
-  locate = TRUE
+  options = NULL,
+  root = NULL
 )
 }
 \arguments{
-\item{id}{Id of the packet to copy from (will become a query, see
-mrc-4418)}
+\item{...}{Arguments passed through to \link{orderly_query},
+perhaps just a query expression}
 
 \item{files}{Files to copy from the other packet. This can be (1)
 a character vector, in which case files are copied over without
@@ -49,35 +48,25 @@ the destination filename by doing \verb{$\{x\}}.}
 
 \item{dest}{The directory to copy into}
 
-\item{allow_remote}{Logical, indicating if we should attempt to
-retrieve the file from any remote location if it cannot be found
-locally. If the file is large, this may take some time depending
-on the speed of the connection. If you use a file store, note
-that this does add the downloaded file into your file store,
-though associated with no packet so that it is subject to
-garbage collection (once we write support for that).}
-
 \item{overwrite}{Overwrite files at the destination; this is
 typically what you want, but set to \code{FALSE} if you would prefer
 that an error be thrown if the destination file already exists.}
 
-\item{envir}{An environment into which string interpolation may
-happen (see the \code{files} argument for details on the string
-interpolation).  The default here is to use the calling
-environment, which is typically reasonable, but may need
-changing in programmatic use.}
+\item{envir}{Optionally, an environment to substitute into the
+query (using the \verb{environment:} prefix). The default here is to
+use the calling environment, but you can explicitly pass this in
+if you want to control where this lookup happens.}
+
+\item{options}{Optionally, a \link{orderly_search_options}
+object for controlling how the search is performed, and which
+packets should be considered in scope. If not provided, default
+options are used (i.e., \code{orderly2::orderly_search_options()})}
 
 \item{root}{The path to the root directory, or \code{NULL} (the
 default) to search for one from the current working directory if
 \code{locate} is \code{TRUE}. This function does not require that the
 directory is configured for orderly, and can be any \code{outpack}
 root (see \link{orderly_init} for details).}
-
-\item{locate}{Logical, indicating if the root should be searched
-for.  If \code{TRUE}, then we looks in the directory given for \code{root}
-(or the working directory if \code{NULL}) and then up through its
-parents until it finds an \code{.outpack} directory or
-\code{orderly_config.yml}}
 }
 \value{
 Nothing, invisibly. Primarily called for its side effect
@@ -88,9 +77,20 @@ Copy files from a packet to anywhere. Similar to
 \link{orderly_dependency} except that this is not used in an
 active packet context. You can use this function to pull files
 from an outpack root to a directory outside of the control of
-outpack, for example.
+outpack, for example. Note that all arguments need must be
+provided by name, not position, with the exception of the id or
+query.
 }
 \details{
+You can call this function with an id as a string, in which case
+we do not search for the packet and proceed regardless of whether
+or not this id is present.  If called with any other arguments
+(e.g., a string that does not match the id format, or a named
+argument \code{name}, \code{subquery} or \code{parameters}) then we interpret the
+arguments as a query and \link{orderly_search} to find the
+id. It is an error if this query does not return exactly one
+packet id, so you probably want to use \code{latest()}.
+
 There are different ways that this might fail (or recover from
 failure):
 \itemize{

--- a/man/orderly_copy_files.Rd
+++ b/man/orderly_copy_files.Rd
@@ -11,7 +11,8 @@ orderly_copy_files(
   overwrite = TRUE,
   envir = parent.frame(),
   options = NULL,
-  root = NULL
+  root = NULL,
+  locate = TRUE
 )
 }
 \arguments{

--- a/man/orderly_copy_files.Rd
+++ b/man/orderly_copy_files.Rd
@@ -68,6 +68,12 @@ default) to search for one from the current working directory if
 \code{locate} is \code{TRUE}. This function does not require that the
 directory is configured for orderly, and can be any \code{outpack}
 root (see \link{orderly_init} for details).}
+
+\item{locate}{Logical, indicating if the root should be searched
+for.  If \code{TRUE}, then we looks in the directory given for \code{root}
+(or the working directory if \code{NULL}) and then up through its
+parents until it finds an \code{.outpack} directory or
+\code{orderly_config.yml}}
 }
 \value{
 Nothing, invisibly. Primarily called for its side effect

--- a/man/orderly_dependency.Rd
+++ b/man/orderly_dependency.Rd
@@ -4,7 +4,7 @@
 \alias{orderly_dependency}
 \title{Declare a dependency}
 \usage{
-orderly_dependency(name, query, use)
+orderly_dependency(name, query, files)
 }
 \arguments{
 \item{name}{The name of the packet to depend on}
@@ -13,10 +13,33 @@ orderly_dependency(name, query, use)
 the string \code{latest}, indicating the most recent version. You may
 want a more complex query here though.}
 
-\item{use}{Files to use from the packet found by \code{query}, usually
-as a named character vector with string interpolation in the
-names; see \link{orderly_copy_files}' \code{file} argument for
-details.}
+\item{files}{Files to copy from the other packet. This can be (1)
+a character vector, in which case files are copied over without
+changing their names, (2) a \strong{named} character vector, in which
+case the name will be used as the destination name, or (3) a
+\link{data.frame} (including \code{tbl_df}, or \code{data.frame} objects)
+containing columns \code{from} and \code{to}, in which case the files
+\code{from} will be copied with names \code{to}.
+
+In all cases, if you want to import a directory of files from a
+packet, you must refer to the source with a trailing slash
+(e.g., \code{c(here = "there/")}), which will create the local
+directory \code{here/...} with files from the upstream packet
+directory \verb{there/}. If you omit the slash then an error will be
+thrown suggesting that you add a slash if this is what you
+intended.
+
+You can use a limited form of string interpolation in the names of
+this argument; using \verb{$\{variable\}} will pick up values from
+\code{envir} and substitute them into your string.  This is similar
+to the interpolation you might be familiar with from
+\code{glue::glue} or similar, but much simpler with no concatenation
+or other fancy features supported.
+
+Note that there is an unfortunate, but (to us) avoidable
+inconsistency here; interpolation of values from your
+environment in the query is done by using \code{environment:x} and in
+the destination filename by doing \verb{$\{x\}}.}
 }
 \value{
 Undefined

--- a/tests/testthat/test-outpack-packet.R
+++ b/tests/testthat/test-outpack-packet.R
@@ -872,7 +872,7 @@ test_that("can pull in directories", {
   id <- p1$id
 
   dest <- withr::local_tempdir()
-  orderly_copy_files(id, c(d = "data/"), dest, root = root)
+  orderly_copy_files(id, files = c(d = "data/"), dest = dest, root = root)
   expect_equal(dir(dest), "d")
   expect_equal(dir(file.path(dest, "d")), letters[1:6])
 
@@ -903,7 +903,7 @@ test_that("exporting directories reports on trailing slashes being missing", {
 
   dest <- withr::local_tempdir()
   expect_error(
-    orderly_copy_files(id, c(d = "data"), dest, root = root),
+    orderly_copy_files(id, files = c(d = "data"), dest = dest, root = root),
     err)
 
   path_src2 <- withr::local_tempdir()

--- a/tests/testthat/test-read.R
+++ b/tests/testthat/test-read.R
@@ -53,19 +53,19 @@ test_that("Can read string from expressions", {
 
 
 test_that("read dependency", {
-  args <- list(name = "a", query = "latest", use = c(x = "y"))
+  args <- list(name = "a", query = "latest", files = c(x = "y"))
   expect_equal(static_orderly_dependency(args), args)
 
   expect_null(
     static_orderly_dependency(list(name = quote(a),
                                    query = "latest",
-                                   use = c(x = "y"))))
+                                   files = c(x = "y"))))
   expect_null(
     static_orderly_dependency(list(name = "a",
                                    query = quote(latest),
-                                   use = c(x = "y"))))
+                                   files = c(x = "y"))))
   expect_null(
     static_orderly_dependency(list(name = "a",
                                    query = "latest",
-                                   use = quote(use))))
+                                   files = quote(files))))
 })

--- a/tests/testthat/test-run.R
+++ b/tests/testthat/test-run.R
@@ -514,9 +514,9 @@ test_that("don't copy artefacts over when not needed", {
 
 test_that("can pull resources programmatically", {
   path <- test_prepare_orderly_example("programmatic-resource")
-  id1 <- orderly2::orderly_run("programmatic-resource", list(use = "a"),
+  id1 <- orderly2::orderly_run("programmatic-resource", list(files = "a"),
                                root = path)
-  id2 <- orderly2::orderly_run("programmatic-resource", list(use = "b"),
+  id2 <- orderly2::orderly_run("programmatic-resource", list(files = "b"),
                                root = path)
   meta1 <- orderly_metadata(id1, root = path)
   meta2 <- orderly_metadata(id2, root = path)
@@ -536,9 +536,9 @@ test_that("can pull resources programmatically, strictly", {
   path <- test_prepare_orderly_example("programmatic-resource")
   path_src <- file.path(path, "src", "programmatic-resource", "orderly.R")
   prepend_lines(path_src, "orderly2::orderly_strict_mode()")
-  id1 <- orderly2::orderly_run("programmatic-resource", list(use = "a"),
+  id1 <- orderly2::orderly_run("programmatic-resource", list(files = "a"),
                                root = path)
-  id2 <- orderly2::orderly_run("programmatic-resource", list(use = "b"),
+  id2 <- orderly2::orderly_run("programmatic-resource", list(files = "b"),
                                root = path)
   meta1 <- meta <- orderly_metadata(id1, root = path)
   meta2 <- meta <- orderly_metadata(id2, root = path)

--- a/tests/testthat/test-run.R
+++ b/tests/testthat/test-run.R
@@ -536,7 +536,7 @@ test_that("can pull resources programmatically, strictly", {
   path <- test_prepare_orderly_example("programmatic-resource")
   path_src <- file.path(path, "src", "programmatic-resource", "orderly.R")
   prepend_lines(path_src, "orderly2::orderly_strict_mode()")
-  id1 <- orderly2::orderly_run("programmatic-resource", list(use= "a"),
+  id1 <- orderly2::orderly_run("programmatic-resource", list(use = "a"),
                                root = path)
   id2 <- orderly2::orderly_run("programmatic-resource", list(use = "b"),
                                root = path)

--- a/tests/testthat/test-run.R
+++ b/tests/testthat/test-run.R
@@ -514,9 +514,9 @@ test_that("don't copy artefacts over when not needed", {
 
 test_that("can pull resources programmatically", {
   path <- test_prepare_orderly_example("programmatic-resource")
-  id1 <- orderly2::orderly_run("programmatic-resource", list(files = "a"),
+  id1 <- orderly2::orderly_run("programmatic-resource", list(use = "a"),
                                root = path)
-  id2 <- orderly2::orderly_run("programmatic-resource", list(files = "b"),
+  id2 <- orderly2::orderly_run("programmatic-resource", list(use = "b"),
                                root = path)
   meta1 <- orderly_metadata(id1, root = path)
   meta2 <- orderly_metadata(id2, root = path)
@@ -536,9 +536,9 @@ test_that("can pull resources programmatically, strictly", {
   path <- test_prepare_orderly_example("programmatic-resource")
   path_src <- file.path(path, "src", "programmatic-resource", "orderly.R")
   prepend_lines(path_src, "orderly2::orderly_strict_mode()")
-  id1 <- orderly2::orderly_run("programmatic-resource", list(files = "a"),
+  id1 <- orderly2::orderly_run("programmatic-resource", list(use= "a"),
                                root = path)
-  id2 <- orderly2::orderly_run("programmatic-resource", list(files = "b"),
+  id2 <- orderly2::orderly_run("programmatic-resource", list(use = "b"),
                                root = path)
   meta1 <- meta <- orderly_metadata(id1, root = path)
   meta2 <- meta <- orderly_metadata(id2, root = path)

--- a/vignettes/introduction.Rmd
+++ b/vignettes/introduction.Rmd
@@ -112,7 +112,8 @@ Once created, you can then refer to this report by id and pull its files whereve
 ```{r}
 dest <- tempfile()
 fs::dir_create(dest)
-orderly2::orderly_copy_files(id, c("final.rds" = "data.rds"), dest, root = path)
+orderly2::orderly_copy_files(id, files = c("final.rds" = "data.rds"),
+                             dest = dest, root = path)
 ```
 
 which copies `data.rds` to some new temporary directory `dest` with name `final.rds`. This uses `orderly2`'s `outpack_` functions, which are designed to interact with outpack archives regardless of how they were created (`orderly2` is a program that creates `outpack` archives). Typically these are lower-level than `orderly_` functions.
@@ -240,8 +241,8 @@ id <- orderly2::orderly_run("random", list(n_samples = 15), root = path)
 Our resulting file has 15 rows, as the parameter we passed in affected the report:
 
 ```{r}
-orderly2::orderly_copy_files(id, c("random.rds" = "data.rds"), dest,
-                             root = path)
+orderly2::orderly_copy_files(id, files = c("random.rds" = "data.rds"),
+                             dest = dest, root = path)
 readRDS(file.path(dest, "random.rds"))
 ```
 

--- a/vignettes/migrating.Rmd
+++ b/vignettes/migrating.Rmd
@@ -44,7 +44,7 @@ would end up within an `orderly.R` script that looks like:
 ```r
 orderly2::orderly_parameters(n_min = 10)
 orderly2::orderly_dependency("raw_data", "latest", 
-                             use = c("raw_data.csv" = "data.csv"))
+                             files = c("raw_data.csv" = "data.csv"))
 orderly2::orderly_resource("metadata.csv")
 orderly2::orderly_artefact("Processed data", "data.rds")
 source("functions.R")


### PR DESCRIPTION
~Merge after #46, contains those commits~

This PR updates orderly_copy_files to accept a query, using the same approach as orderly_metadata_extract (#39). There was already quite a bit of overlap between the arguments as passed through to the original function and to `orderly_search` so this feels fairly nice, even though all the additional arguments must now be named.