### PR TITLE
Update to cope with new lintr release

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -42,6 +42,14 @@ jobs:
           http-user-agent: ${{ matrix.config.http-user-agent }}
           use-public-rspm: true
 
+      # This does take a minute or two to install, and we could cache
+      # it but that's not super easy while still allowing easy
+      # updating. Once things stabilise we might tag outpack server
+      # releases and then we can install and cache against that.
+      - name: setup server
+        run: |
+          cargo install --git https://github.com/mrc-ide/outpack_server --branch mrc-4364
+
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:
           extra-packages: any::rcmdcheck

--- a/.github/workflows/test-coverage.yaml
+++ b/.github/workflows/test-coverage.yaml
@@ -21,6 +21,10 @@ jobs:
         with:
           use-public-rspm: true
 
+      - name: setup server
+        run: |
+          cargo install --git https://github.com/mrc-ide/outpack_server --branch mrc-4364
+
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:
           extra-packages: any::covr

--- a/.lintr
+++ b/.lintr
@@ -1,4 +1,5 @@
 linters: linters_with_defaults(
+    indentation_linter = NULL,
     object_length_linter = NULL,
     object_usage_linter = NULL,
     cyclocomp_linter = NULL


### PR DESCRIPTION
This is going to affect basically all our repos, the default does not conform to our style...

Also installing outpack_server here, that was missed because codecov/github were flakey last week