### PR TITLE
Consistency of environment names

### DIFF
--- a/R/config.R
+++ b/R/config.R
@@ -8,7 +8,7 @@ orderly_config_read <- function(path) {
     assert_named(raw)
   }
 
-  raw <- resolve_env(raw, orderly_envir_read(path), "orderly_config.yml")
+  raw <- resolve_envvar(raw, orderly_envir_read(path), "orderly_config.yml")
 
   check <- list(
     minimum_orderly_version = orderly_config_validate_minimum_orderly_version,

--- a/R/context.R
+++ b/R/context.R
@@ -5,7 +5,7 @@ orderly_context <- function() {
     path <- p$path
     root <- p$root$path
     config <- p$orderly2$config
-    env <- p$orderly2$envir
+    envir <- p$orderly2$envir
     src <- p$orderly2$src
     parameters <- p$parameters
     name <- p$name
@@ -17,14 +17,14 @@ orderly_context <- function() {
     config <- root_open(root,
                         locate = FALSE,
                         require_orderly = TRUE)$config$orderly
-    env <- orderly_environment("orderly2")
+    envir <- orderly_environment("orderly2")
     src <- path
-    parameters <- current_orderly_parameters(src, env)
+    parameters <- current_orderly_parameters(src, envir)
     name <- basename(path)
     id <- NA_character_
     search_options <- .interactive$search_options
   }
-  list(is_active = is_active, path = path, config = config, env = env,
+  list(is_active = is_active, path = path, config = config, envir = envir,
        root = root, src = src, name = name, id = id, parameters = parameters,
        search_options = search_options, packet = p)
 }

--- a/R/evaluate.R
+++ b/R/evaluate.R
@@ -47,8 +47,8 @@ source_and_capture <- function(path, envir, echo) {
     unlink(tmp)
   })
 
-  env <- new.env(parent = emptyenv())
-  env$warnings <- collector()
+  local <- new.env(parent = emptyenv())
+  local$warnings <- collector()
 
   res <- tryCatch(
     withr::with_output_sink(
@@ -58,20 +58,20 @@ source_and_capture <- function(path, envir, echo) {
         withCallingHandlers(
           source_echo(path, envir),
           warning = function(e) {
-            env$warnings$add(e)
+            local$warnings$add(e)
             tryInvokeRestart("muffleWarning")
           },
           error = function(e) {
             try(stop(e))
-            env$error <- e
-            env$traceback <- utils::limitedLabels(sys.calls())
+            local$error <- e
+            local$traceback <- utils::limitedLabels(sys.calls())
           }))),
     error = identity)
 
-  list(success = is.null(env$error),
-       error = env$error,
-       traceback = env$traceback,
-       warnings = env$warnings$get(),
+  list(success = is.null(local$error),
+       error = local$error,
+       traceback = local$traceback,
+       warnings = local$warnings$get(),
        output = readLines(tmp))
 }
 

--- a/R/metadata.R
+++ b/R/metadata.R
@@ -55,8 +55,8 @@ orderly_parameters <- function(...) {
   p <- get_active_packet()
   if (is.null(p)) {
     pars <- static_orderly_parameters(list(...))
-    env <- parent.frame()
-    check_parameters_interactive(env, pars)
+    envir <- parent.frame()
+    check_parameters_interactive(envir, pars)
   }
 
   invisible()
@@ -74,10 +74,10 @@ static_orderly_parameters <- function(args) {
 }
 
 
-current_orderly_parameters <- function(src, env) {
+current_orderly_parameters <- function(src, envir) {
   dat <- orderly_read(src)
   pars <- static_orderly_parameters(dat$parameters)
-  values <- check_parameters_interactive(env, pars)
+  values <- check_parameters_interactive(envir, pars)
   values
 }
 
@@ -256,12 +256,12 @@ orderly_dependency <- function(name, query, files) {
   if (ctx$is_active) {
     outpack_packet_use_dependency(ctx$packet, query, files,
                                   search_options = search_options,
-                                  envir = ctx$env,
+                                  envir = ctx$envir,
                                   overwrite = TRUE)
   } else {
     orderly_copy_files(query, files = files, dest = ctx$path, overwrite = TRUE,
                        parameters = ctx$parameters, options = search_options,
-                       envir = ctx$env, root = ctx$root)
+                       envir = ctx$envir, root = ctx$root)
   }
 
   invisible()

--- a/R/outpack_logging.R
+++ b/R/outpack_logging.R
@@ -130,8 +130,8 @@ log_console <- function(topic, detail, caller, log_level) {
 
 
 log_collector_json <- function() {
-  env <- new.env(parent = emptyenv())
-  env$data <- list()
+  envir <- new.env(parent = emptyenv())
+  envir$data <- list()
   list(
     append = function(topic, detail, caller, log_level) {
       el <- list(topic = topic,
@@ -139,10 +139,10 @@ log_collector_json <- function() {
                  caller = caller,
                  log_level = log_level,
                  time = as.numeric(Sys.time()))
-      env$data <- c(env$data, list(el))
+      envir$data <- c(envir$data, list(el))
     },
     get = function() {
-      log_serialise(env$data)
+      log_serialise(envir$data)
     }
   )
 }

--- a/R/outpack_misc.R
+++ b/R/outpack_misc.R
@@ -78,7 +78,7 @@ validate_parameters <- function(parameters) {
 }
 
 
-validate_file_from_to <- function(x, environment,
+validate_file_from_to <- function(x, envir,
                                   name = deparse(substitute(x)),
                                   call = NULL) {
   ## Later, we can expand this to support a data.frame too perhaps?
@@ -96,7 +96,7 @@ validate_file_from_to <- function(x, environment,
       call = call)
   }
 
-  to_value <- string_interpolate_simple(to, environment, call)
+  to_value <- string_interpolate_simple(to, envir, call)
 
   if (any(duplicated(to_value))) {
     dups <- unique(to_value[duplicated(to_value)])

--- a/R/outpack_tools.R
+++ b/R/outpack_tools.R
@@ -189,7 +189,7 @@ orderly_metadata_extract <- function(..., extract = NULL, root = NULL,
 
   meta <- lapply(ids, root$metadata, full = TRUE)
 
-  env <- environment()
+  envir <- environment()
   ret <- data_frame(id = ids)
   for (i in seq_len(nrow(extract))) {
     from_i <- extract$from[[i]]
@@ -197,7 +197,7 @@ orderly_metadata_extract <- function(..., extract = NULL, root = NULL,
     value_i <- lapply(meta, function(x) {
       tryCatch(x[[from_i]], error = function(e) NULL)
     })
-    ret[[extract$to[[i]]]] <- extract_convert(ids, value_i, from_i, is_i, env)
+    ret[[extract$to[[i]]]] <- extract_convert(ids, value_i, from_i, is_i, envir)
   }
 
   ret

--- a/R/plugin.R
+++ b/R/plugin.R
@@ -123,7 +123,7 @@ orderly_plugin <- function(config, serialise, cleanup, schema) {
 ##'   with the plugin's `read` function (see
 ##'   [`orderly2::orderly_plugin_register`])
 ##'
-##' * `env`: the environment that the packet is running in. Often this
+##' * `envir`: the environment that the packet is running in. Often this
 ##'   will be the global environment, but do not assume this! You may
 ##'   read and write from this environment.
 ##'
@@ -150,7 +150,7 @@ orderly_plugin_context <- function(name) {
   ctx$packet <- NULL
   ## Correct environment in the interactive case:
   if (!ctx$is_active) {
-    ctx$env <- orderly_environment(name)
+    ctx$envir <- orderly_environment(name)
   }
   ctx
 }

--- a/R/query_search.R
+++ b/R/query_search.R
@@ -115,12 +115,12 @@ as_orderly_search_options <- function(x, name = deparse(substitute(x))) {
 }
 
 
-orderly_query_eval <- function(query, parameters, environment, options, root) {
+orderly_query_eval <- function(query, parameters, envir, options, root) {
   assert_is(query, "orderly_query")
   assert_is(options, "orderly_search_options")
   assert_is(root, "outpack_root")
   validate_parameters(parameters)
-  assert_is(environment, "environment")
+  assert_is(envir, "environment")
   ## It's simple enough here to pre-compare the provided parameters
   ## with query$info$parameters, but we already have nicer error
   ## reporting at runtime that shows the context of where the
@@ -130,7 +130,7 @@ orderly_query_eval <- function(query, parameters, environment, options, root) {
   ## All the (possibly mutable) bits that define our query environment.
   query_env <- list(index = index,
                     parameters = parameters,
-                    environment = environment,
+                    envir = envir,
                     subquery = list2env(query$subquery))
 
   query_eval(query$value, query_env)
@@ -189,7 +189,7 @@ query_eval_subquery <- function(query, query_env) {
     ## they might be relevant?
     subquery_env <- list(index = query_env$index,
                          parameters = NULL,
-                         environment = query_env$environment,
+                         envir = query_env$envir,
                          subquery = subquery)
     result <- query_eval(subquery[[name]]$parsed, subquery_env)
     subquery[[name]]$result <- result
@@ -221,7 +221,7 @@ query_eval_lookup <- function(query, query_env) {
            query$query, query_env$parameters, "parameters",
            query$expr, query$context),
          environment = query_eval_lookup_get(
-           query$query, query_env$environment, "environment",
+           query$query, query_env$envir, "environment",
            query$expr, query$context),
          ## Normally unreachable
          stop("Unhandled lookup [outpack bug - please report]"))

--- a/R/run.R
+++ b/R/run.R
@@ -326,14 +326,14 @@ check_parameter_values <- function(given, defaults) {
 }
 
 
-check_parameters_interactive <- function(env, spec) {
+check_parameters_interactive <- function(envir, spec) {
   if (length(spec) == 0) {
     return()
   }
 
   is_required <- vlapply(spec, is.null)
 
-  msg <- setdiff(names(spec)[is_required], names(env))
+  msg <- setdiff(names(spec)[is_required], names(envir))
   if (length(msg) > 0L) {
     ## This will change, but we'll need some interactive prompting
     ## better done in another ticket. See
@@ -346,12 +346,12 @@ check_parameters_interactive <- function(env, spec) {
   }
 
   ## Set any missing values into the environment:
-  list2env(spec[setdiff(names(spec), names(env))], env)
+  list2env(spec[setdiff(names(spec), names(envir))], envir)
 
   ## We might need a slightly better error message here that indicates
   ## that we're running in a pecular mode so the value might just have
   ## been overwritten
-  found <- set_names(lapply(names(spec), function(v) env[[v]]), names(spec))
+  found <- set_names(lapply(names(spec), function(v) envir[[v]]), names(spec))
   check_parameter_values(found[!vlapply(found, is.null)], FALSE)
   invisible(found)
 }

--- a/R/util.R
+++ b/R/util.R
@@ -404,15 +404,15 @@ collapseq <- function(x) {
 ##
 ## I've gone with a shell-expansion like ${var} syntax here. If this
 ## is not suitable, users can always do their own substitutions.
-string_interpolate_simple <- function(x, environment, call = NULL) {
+string_interpolate_simple <- function(x, envir, call = NULL) {
   if (inherits(x, "AsIs") || !any(grepl("${", x, fixed = TRUE))) {
     return(x)
   }
-  vcapply(x, string_interpolate_simple1, environment, call, USE.NAMES = FALSE)
+  vcapply(x, string_interpolate_simple1, envir, call, USE.NAMES = FALSE)
 }
 
 
-string_interpolate_simple1 <- function(x, environment, call) {
+string_interpolate_simple1 <- function(x, envir, call) {
   re <- "\\$\\{\\s*(.*?)\\s*\\}"
 
   m <- gregexec(re, x)[[1L]]
@@ -428,7 +428,7 @@ string_interpolate_simple1 <- function(x, environment, call) {
 
   to_value <- lapply(to, function(el) {
     value <- tryCatch(
-      get(el, environment),
+      get(el, envir),
       error = function(e) {
         cli::cli_abort(
           c(sprintf("Failed to find value for '%s'", el),

--- a/R/util.R
+++ b/R/util.R
@@ -81,9 +81,10 @@ replace_ragged <- function(x, i, values) {
 }
 
 
-resolve_env <- function(x, env, used_in, error = TRUE) {
-  if (!is.null(env)) {
-    withr::local_envvar(env)
+## Not R environments, but system environment variables
+resolve_envvar <- function(x, variables, used_in, error = TRUE) {
+  if (!is.null(variables)) {
+    withr::local_envvar(variables)
   }
 
   make_name <- function(x, parent) {
@@ -318,14 +319,14 @@ last <- function(x) {
 
 
 collector <- function() {
-  env <- new.env(parent = emptyenv())
-  env$data <- list()
+  envir <- new.env(parent = emptyenv())
+  envir$data <- list()
   list(
     add = function(x) {
-      env$data <- c(env$data, list(x))
+      envir$data <- c(envir$data, list(x))
     },
     get = function() {
-      env$data
+      envir$data
     }
   )
 }

--- a/man/orderly_plugin_context.Rd
+++ b/man/orderly_plugin_context.Rd
@@ -21,7 +21,7 @@ or similar. You may create files here.
 \item \code{config}: the configuration for this plugin, after processing
 with the plugin's \code{read} function (see
 \code{\link{orderly_plugin_register}})
-\item \code{env}: the environment that the packet is running in. Often this
+\item \code{envir}: the environment that the packet is running in. Often this
 will be the global environment, but do not assume this! You may
 read and write from this environment.
 \item \code{src}: the path to the packet source directory. This is

--- a/tests/testthat/helper-orderly.R
+++ b/tests/testthat/helper-orderly.R
@@ -72,12 +72,12 @@ append_lines <- function(path, lines) {
 
 
 reset_interactive <- function() {
-  clear_env(.interactive)
+  clear_envir(.interactive)
 }
 
 
-clear_env <- function(env) {
-  rm(list = ls(env), envir = env)
+clear_envir <- function(envir) {
+  rm(list = ls(envir), envir = envir)
 }
 
 

--- a/tests/testthat/plugins/example.random/R/random.R
+++ b/tests/testthat/plugins/example.random/R/random.R
@@ -1,7 +1,7 @@
 numbers <- function(as, n) {
   ctx <- orderly2::orderly_plugin_context("example.random")
   x <- ctx$config$generator(n)
-  ctx$env[[as]] <- x
+  ctx$envir[[as]] <- x
   info <- list(as = as, mean = mean(x), variance = var(x))
   orderly2::orderly_plugin_add_metadata("example.random", "numbers", info)
   invisible()

--- a/tests/testthat/test-cleanup.R
+++ b/tests/testthat/test-cleanup.R
@@ -1,9 +1,9 @@
 test_that("can cleanup explicit things quite well", {
   path <- test_prepare_orderly_example("explicit")
-  env <- new.env()
+  envir <- new.env()
   path_src <- file.path(path, "src", "explicit")
   withr::with_dir(path_src,
-                  sys.source("orderly.R", env))
+                  sys.source("orderly.R", envir))
   status <- withr::with_dir(path_src, orderly_cleanup_status())
 
   expect_s3_class(status, "orderly_cleanup_status")
@@ -34,7 +34,7 @@ test_that("can cleanup explicit things quite well", {
 test_that("can clean up unknown files if gitignored", {
   skip_if_older_gert()
   path <- test_prepare_orderly_example("explicit")
-  env <- new.env()
+  envir <- new.env()
   path_src <- file.path(path, "src", "explicit")
   helper_add_git(path)
 
@@ -117,10 +117,10 @@ test_that("can clean up dependencies", {
 
 test_that("can clean up directories", {
   path <- test_prepare_orderly_example("directories")
-  env <- new.env()
+  envir <- new.env()
   path_src <- file.path(path, "src", "directories")
   withr::with_dir(path_src,
-                  sys.source("orderly.R", env))
+                  sys.source("orderly.R", envir))
   status <- orderly_cleanup_status("directories", path)
 
   files <- c("data/a.csv", "data/b.csv", "orderly.R",

--- a/tests/testthat/test-interactive.R
+++ b/tests/testthat/test-interactive.R
@@ -1,7 +1,7 @@
 test_that("can detect orderly directory", {
   path <- test_prepare_orderly_example("explicit")
-  env <- new.env()
-  id <- orderly_run("explicit", root = path, envir = env)
+  envir <- new.env()
+  id <- orderly_run("explicit", root = path, envir = envir)
 
   expect_error(
     detect_orderly_interactive_path(path),

--- a/tests/testthat/test-outpack-logging.R
+++ b/tests/testthat/test-outpack-logging.R
@@ -38,7 +38,7 @@ test_that("can log basic packet running", {
   path_src <- create_temporary_simple_src()
 
   inputs <- c("data.csv", "script.R")
-  env <- new.env()
+  envir <- new.env()
 
   msg <- capture_messages(
     p <- outpack_packet_start(path_src, "example", root = root))
@@ -49,7 +49,7 @@ test_that("can log basic packet running", {
   expect_match(msg[[3]], "^\\[ start")
 
   res <- evaluate_promise(
-    outpack_packet_run(p, "script.R", env))
+    outpack_packet_run(p, "script.R", envir))
   expect_equal(res$messages,
                c("[ script     ]  script.R\n", "[ result     ]  success\n"))
 

--- a/tests/testthat/test-outpack-misc.R
+++ b/tests/testthat/test-outpack-misc.R
@@ -72,19 +72,19 @@ test_that("Can select multiple dependencies at once", {
 
 
 test_that("can validate file renaming inputs", {
-  env <- list2env(list(a = "aaa", b = "bbb"), parent = emptyenv())
+  envir <- list2env(list(a = "aaa", b = "bbb"), parent = emptyenv())
   expect_equal(
-    validate_file_from_to("a", env),
+    validate_file_from_to("a", envir),
     data_frame(from = "a", to = "a"))
   expect_equal(
-    validate_file_from_to(c("a", B = "b"), env),
+    validate_file_from_to(c("a", B = "b"), envir),
     data_frame(from = c("a", "b"), to = c("a", "B")))
   expect_equal(
-    validate_file_from_to(c("${a}/a" = "a"), env),
+    validate_file_from_to(c("${a}/a" = "a"), envir),
     data_frame(from = "a", to = "aaa/a"))
 
   err <- expect_error(
-    validate_file_from_to(1, env, "files"),
+    validate_file_from_to(1, envir, "files"),
     "Unexpected object type for 'files'")
   expect_equal(
     err$body,
@@ -92,11 +92,11 @@ test_that("can validate file renaming inputs", {
       i = "Expected a (named) character vector"))
 
   expect_error(
-    validate_file_from_to(c("a", "a"), env, "files"),
+    validate_file_from_to(c("a", "a"), envir, "files"),
     "Every destination filename (in 'files') must be unique",
     fixed = TRUE)
   expect_error(
-    validate_file_from_to(c("a" = "x", "a" = "y"), env, "files"),
+    validate_file_from_to(c("a" = "x", "a" = "y"), envir, "files"),
     "Every destination filename (in 'files') must be unique",
     fixed = TRUE)
 })

--- a/tests/testthat/test-outpack-tools.R
+++ b/tests/testthat/test-outpack-tools.R
@@ -152,13 +152,13 @@ test_that("fill in types for git data when missing", {
 
 test_that("can extract orderly metadata", {
   path <- test_prepare_orderly_example(c("parameters", "description"))
-  env <- new.env()
+  envir <- new.env()
   ids1 <- vcapply(1:3, function(i) {
-    orderly_run("parameters", root = path, envir = env,
+    orderly_run("parameters", root = path, envir = envir,
                 parameters = list(a = i, b = 20, c = 30))
   })
   ids2 <- vcapply(1:2, function(i) {
-    orderly_run("description", root = path, envir = env)
+    orderly_run("description", root = path, envir = envir)
   })
 
   expect_equal(
@@ -179,8 +179,8 @@ test_that("can extract orderly metadata", {
 test_that("can extract orderly custom metadata", {
   ## This is example in the docs
   path <- test_prepare_orderly_example("description")
-  env <- new.env()
-  id <- orderly_run("description", root = path, envir = env)
+  envir <- new.env()
+  id <- orderly_run("description", root = path, envir = envir)
   d <- orderly_metadata_extract(
     'name == "description"',
     extract = c(display = "custom.orderly.description.display is string"),
@@ -191,9 +191,9 @@ test_that("can extract orderly custom metadata", {
 
 test_that("can extract session metadata", {
   path <- test_prepare_orderly_example("parameters")
-  env <- new.env()
+  envir <- new.env()
   ids <- vcapply(1:3, function(i) {
-    orderly_run("parameters", root = path, envir = env,
+    orderly_run("parameters", root = path, envir = envir,
                 parameters = list(a = i, b = 20, c = 30))
   })
   meta <- lapply(ids, orderly_metadata, root = path)

--- a/tests/testthat/test-parameters.R
+++ b/tests/testthat/test-parameters.R
@@ -69,25 +69,25 @@ test_that("combine default and given parameters", {
 
 
 test_that("do nothing when no spec given", {
-  env <- new.env()
-  expect_null(check_parameters_interactive(env, NULL))
-  expect_equal(ls(env), character())
+  envir <- new.env()
+  expect_null(check_parameters_interactive(envir, NULL))
+  expect_equal(ls(envir), character())
 })
 
 
 test_that("set defaults into environment if missing", {
-  env <- new.env()
-  check_parameters_interactive(env, list(a = 1, b = 2))
-  expect_setequal(names(env), c("a", "b"))
-  expect_equal(env$a, 1)
-  expect_equal(env$b, 2)
+  envir <- new.env()
+  check_parameters_interactive(envir, list(a = 1, b = 2))
+  expect_setequal(names(envir), c("a", "b"))
+  expect_equal(envir$a, 1)
+  expect_equal(envir$b, 2)
 })
 
 
 test_that("require non-default parameters are present in environment", {
-  env <- list2env(list(b = 3, c = 4), parent = new.env())
+  envir <- list2env(list(b = 3, c = 4), parent = new.env())
   expect_error(
-    check_parameters_interactive(env, list(a = NULL, b = NULL, c = NULL)),
+    check_parameters_interactive(envir, list(a = NULL, b = NULL, c = NULL)),
     "Missing parameters: 'a'")
 })
 

--- a/tests/testthat/test-plugin.R
+++ b/tests/testthat/test-plugin.R
@@ -1,14 +1,14 @@
 test_that("Can run simple example with plugin", {
   path <- test_prepare_orderly_example("plugin")
 
-  env <- new.env()
+  envir <- new.env()
   set.seed(1)
-  id <- orderly_run("plugin", root = path, envir = env)
+  id <- orderly_run("plugin", root = path, envir = envir)
 
   set.seed(1)
   cmp <- rnorm(10)
 
-  expect_identical(env$dat, cmp)
+  expect_identical(envir$dat, cmp)
 
   meta <- orderly_metadata(id, root = path)
 
@@ -27,16 +27,16 @@ test_that("Can run simple example with plugin", {
 test_that("can run interactive example with plugin", {
   path <- test_prepare_orderly_example("plugin")
 
-  env <- new.env()
+  envir <- new.env()
   set.seed(1)
   path_src <- file.path(path, "src", "plugin")
   withr::with_dir(path_src,
-                  sys.source("orderly.R", env))
+                  sys.source("orderly.R", envir))
 
   set.seed(1)
   cmp <- rnorm(10)
 
-  expect_identical(env$dat, cmp)
+  expect_identical(envir$dat, cmp)
   expect_setequal(dir(path_src), c("data.rds", "orderly.R"))
   expect_equal(readRDS(file.path(path_src, "data.rds")), cmp)
 })
@@ -91,9 +91,9 @@ test_that("error if packet uses non-configured plugin", {
   path <- test_prepare_orderly_example("plugin")
   writeLines(empty_config_contents(), file.path(path, "orderly_config.yml"))
 
-  env <- new.env()
+  envir <- new.env()
   expect_error(
-    orderly_run("plugin", root = path, envir = env),
+    orderly_run("plugin", root = path, envir = envir),
     "Plugin 'example.random' not enabled in 'orderly_config.yml'",
     fixed = TRUE)
 })
@@ -115,9 +115,9 @@ test_that("run cleanup on exit", {
   mock_cleanup <- mockery::mock()
   .plugins$example.random$cleanup <- mock_cleanup
 
-  env <- new.env()
+  envir <- new.env()
   set.seed(1)
-  id <- orderly_run("plugin", root = path, envir = env)
+  id <- orderly_run("plugin", root = path, envir = envir)
 
   mockery::expect_called(mock_cleanup, 1)
   expect_equal(

--- a/tests/testthat/test-query-search.R
+++ b/tests/testthat/test-query-search.R
@@ -125,17 +125,17 @@ test_that("Can filter based on given values", {
            "  - while evaluating this:x\n",
            "  - within           latest(parameter:a == this:x)"),
     fixed = TRUE)
-  env <- list2env(list(a = sum), parent = emptyenv())
+  envir <- list2env(list(a = sum), parent = emptyenv())
   expect_error(
     orderly_search(quote(latest(parameter:a == environment:x)),
-                  envir = env, root = root),
+                  envir = envir, root = root),
     paste0("Did not find 'x' within given environment (containing 'a')\n",
            "  - while evaluating environment:x\n",
            "  - within           latest(parameter:a == environment:x)"),
     fixed = TRUE)
   expect_error(
     orderly_search(quote(latest(parameter:a == environment:a)),
-                  envir = env, root = root),
+                  envir = envir, root = root),
     paste0("The value of 'a' from environment is not suitable as a lookup\n",
            "  - while evaluating environment:a\n",
            "  - within           latest(parameter:a == environment:a)"),
@@ -149,16 +149,16 @@ test_that("can use variables from the environment when searching", {
   x1 <- vcapply(1:3, function(i) create_random_packet(root, "x", list(a = 1)))
   x2 <- vcapply(1:3, function(i) create_random_packet(root, "x", list(a = 2)))
 
-  env <- new.env()
-  env$x <- 1
+  envir <- new.env()
+  envir$x <- 1
   expect_equal(
     orderly_search(quote(latest(parameter:a == environment:x)),
-                   envir = env, root = root),
+                   envir = envir, root = root),
     x1[[3]])
 
   expect_error(
     orderly_search(quote(latest(parameter:a == environment:other)),
-                   envir = env, root = root),
+                   envir = envir, root = root),
     "Did not find 'other' within given environment (containing 'x')",
     fixed = TRUE)
 })

--- a/vignettes/plugins.Rmd
+++ b/vignettes/plugins.Rmd
@@ -178,7 +178,7 @@ query <- function(sql, as) {
   con <- DBI::dbConnect(RSQLite::SQLite(), dbname)
   on.exit(DBI::dbDisconnect(con))
   d <- DBI::dbGetQuery(con, sql)
-  ctx$env[[as]] <- d
+  ctx$envir[[as]] <- d
   invisible()
 }
 ```
@@ -186,9 +186,9 @@ query <- function(sql, as) {
 The arguments here are whatever you want the user to provide -- nothing here is special to `orderly2`. The important function here to call is `orderly2::orderly_plugin_context` which returns information that you can use to make the plugin work. This is explained in `?orderly2::orderly_plugin_context`, but in this example we use two elements:
 
 * `config`: the configuration fo this plugin (i.e., the return value from our function `db_config`)
-* `env`: the (R) environment that the current packet is using
+* `envir`: the (R) environment that the current packet is using
 
-We modify the packet environment by writing to `ctx$env`. Finally, we return metadata to save into the final packet metadata, but here we return `NULL`, so this is always empty.  Later, we'll show why and how to change this.
+We modify the packet environment by writing to `ctx$envir`. Finally, we return metadata to save into the final packet metadata, but here we return `NULL`, so this is always empty.  Later, we'll show why and how to change this.
 
 The last bit of package code is to register the plugin, we do this by calling `orderly2::orderly_plugin_register` within `.onLoad()` which is a special R function called when a package is loaded. This means that whenever your packages is loaded (regardless of whether it is attached) it will register the plugin.
 
@@ -275,7 +275,7 @@ query <- function(sql, as) {
   con <- DBI::dbConnect(RSQLite::SQLite(), dbname)
   on.exit(DBI::dbDisconnect(con))
   d <- DBI::dbGetQuery(con, sql)
-  ctx$env[[as]] <- d
+  ctx$envir[[as]] <- d
   info <- list(sql = sql, as = as, rows = nrow(d), cols = names(d))
   orderly2::orderly_plugin_add_metadata("example.db", "query", info)
   invisible()


### PR DESCRIPTION
~Merge after #51~

This one is super boring. Use `envir` for all arguments that refer to environments.  I kept on being tripped up by this. We retain `environment` for the query lookup as `envir:x` looks weird