### PR TITLE
Allow empty src directory in orderly_list_src

### DIFF
--- a/R/orderly.R
+++ b/R/orderly.R
@@ -15,6 +15,9 @@
 orderly_list_src <- function(root = NULL, locate = TRUE) {
   root <- root_open(root, locate = locate, require_orderly = TRUE,
                     call = environment())
+  if (!file.exists(file.path(root$path, "src"))) {
+    return(character())
+  }
   pos <- fs::dir_ls(file.path(root$path, "src"), type = "directory")
   basename(pos)[file_exists(file.path(pos, "orderly.R"))]
 }

--- a/tests/testthat/test-orderly.R
+++ b/tests/testthat/test-orderly.R
@@ -19,3 +19,13 @@ test_that("ignore paths without orderly.R", {
   unlink(file.path(path, "src", v[1], "orderly.R"))
   expect_equal(orderly_list_src(path), v[-1])
 })
+
+
+test_that("no candidates returns empty character vector", {
+  path <- test_prepare_orderly_example(character())
+  unlink(file.path(path, "src"), recursive = TRUE)
+  expect_setequal(dir(path, all.files = TRUE, no.. = TRUE),
+                  c(".outpack", "orderly_config.yml"))
+  expect_equal(withr::with_dir(path, orderly_list_src()), character())
+  expect_equal(orderly_list_src(path), character())
+})


### PR DESCRIPTION
Just ran into this, and was surprised