### PR TITLE
Allow orderly_location_pull_packet to accept queries

### DIFF
--- a/R/location.R
+++ b/R/location.R
@@ -293,7 +293,7 @@ orderly_location_pull_packet <- function(..., recursive = NULL,
         "If specifying 'options' in '...', 'allow_remote' must be TRUE",
         i = "If FALSE, then we can't find a packet you don't already have :)")
     }
-    ids <- orderly_search(..., options = options, root = root)
+    ids <- orderly_search(..., root = root)
   }
 
   index <- root$index()

--- a/R/location.R
+++ b/R/location.R
@@ -273,27 +273,20 @@ orderly_location_pull_metadata <- function(location = NULL, root = NULL,
 ##'
 ##' @return Invisibly, the ids of packets that were pulled
 ##' @export
-orderly_location_pull_packet <- function(..., recursive = NULL,
+orderly_location_pull_packet <- function(..., options = NULL, recursive = NULL,
                                          root = NULL, locate = TRUE) {
   root <- root_open(root, locate = locate, require_orderly = FALSE,
                     call = environment())
+  options <- as_orderly_search_options(options, list(allow_remote = TRUE))
+  if (!options$allow_remote) {
+    cli::cli_abort(
+      "If specifying 'options', 'allow_remote' must be TRUE",
+      i = "If FALSE, then we can't find a packet you don't already have :)")
+  }
   if (dots_is_literal_id(...)) {
     ids <- ..1
-    options <- orderly_search_options(allow_remote = TRUE)
   } else {
-    options <- list(...)$options
-    if (is.null(options)) {
-      options <- orderly_search_options(allow_remote = TRUE)
-    } else if (!options$allow_remote) {
-      ## we can't easily modify this arg in place, though with rlang
-      ## this might be possible - see examples in
-      ## https://rlang.r-lib.org/reference/list2.html, and in
-      ## particular the '!!!' splicing operator.
-      cli::cli_abort(
-        "If specifying 'options' in '...', 'allow_remote' must be TRUE",
-        i = "If FALSE, then we can't find a packet you don't already have :)")
-    }
-    ids <- orderly_search(..., root = root)
+    ids <- orderly_search(..., options = options, root = root)
   }
 
   index <- root$index()

--- a/R/location.R
+++ b/R/location.R
@@ -259,9 +259,9 @@ orderly_location_pull_metadata <- function(location = NULL, root = NULL,
 ##'   - in particular, passing `NULL` will match everything that every
 ##'   remote has!
 ##'
-##' @param search_options Options passed to
-##'   [orderly2::orderly_search]. Only the `location` option here is
-##'   preseved, as `allow_remote` must be `TRUE`
+##' @param options Options passed to [orderly2::orderly_search].
+##'   The option `allow_remote` must be `TRUE` as otherwise no packet could
+##'   possibly be pulled, so an error is thrown if this is FALSE.
 ##'
 ##' @param recursive If non-NULL, a logical, indicating if we should
 ##'   recursively pull all packets that are referenced by the packets

--- a/R/outpack_packet.R
+++ b/R/outpack_packet.R
@@ -293,8 +293,7 @@ outpack_packet_use_dependency <- function(packet, query, files,
     packet$root$config$core$require_complete_tree &&
     !(id %in% packet$root$index()$unpacked)
   if (needs_pull) {
-    orderly_location_pull_packet(id, search_options$location,
-                                 root = packet$root)
+    orderly_location_pull_packet(id, root = packet$root)
   }
 
   result <- orderly_copy_files(id, files = files, dest = packet$path,

--- a/R/query_search.R
+++ b/R/query_search.R
@@ -87,15 +87,19 @@ orderly_search_options <- function(location = NULL,
 }
 
 
-as_orderly_search_options <- function(x, name = deparse(substitute(x))) {
+as_orderly_search_options <- function(x, defaults = list(),
+                                      name = deparse(substitute(x))) {
   if (!is.name(name)) {
     name <- "options"
   }
-  if (is.null(x)) {
-    return(orderly_search_options())
-  }
   if (inherits(x, "orderly_search_options")) {
     return(x)
+  }
+  if (is.null(x)) {
+    if (length(defaults) == 0) {
+      return(orderly_search_options())
+    }
+    x <- list()
   }
   if (!is.list(x)) {
     stop(sprintf(
@@ -108,6 +112,11 @@ as_orderly_search_options <- function(x, name = deparse(substitute(x))) {
     stop(sprintf("Invalid option passed to 'orderly_search_options': %s",
                  paste(squote(err), collapse = ", ")),
          call. = FALSE)
+  }
+  for (i in names(defaults)) {
+    if (is.null(x[[i]])) {
+      x[[i]] <- defaults[[i]]
+    }
   }
   do.call(orderly_search_options, x)
 }

--- a/man/orderly_location_pull_packet.Rd
+++ b/man/orderly_location_pull_packet.Rd
@@ -5,20 +5,23 @@
 \title{Pull a single packet from a location}
 \usage{
 orderly_location_pull_packet(
-  id,
-  location = NULL,
+  ...,
+  options = NULL,
   recursive = NULL,
   root = NULL,
   locate = TRUE
 )
 }
 \arguments{
-\item{id}{The id of the packet(s) to pull}
-
-\item{location}{Control the location that the packet can be pulled
-from.  The default (\code{NULL}) will try and pull the packet from
-anywhere it can be found.  Provide a string or character vector
-to limit the search to a particular location or locations.}
+\item{...}{Arguments passed through to
+\link{orderly_search}. In the special case where the first
+argument is a character vector of ids \emph{and} there are no named
+dot arguments, then we interpret this argument as a vector of
+ids directly. Be careful here, your query may pull a lot of data
+\itemize{
+\item in particular, passing \code{NULL} will match everything that every
+remote has!
+}}
 
 \item{recursive}{If non-NULL, a logical, indicating if we should
 recursively pull all packets that are referenced by the packets
@@ -37,14 +40,19 @@ for.  If \code{TRUE}, then we looks in the directory given for \code{root}
 (or the working directory if \code{NULL}) and then up through its
 parents until it finds an \code{.outpack} directory or
 \code{orderly_config.yml}}
+
+\item{search_options}{Options passed to
+\link{orderly_search}. Only the \code{location} option here is
+preseved, as \code{allow_remote} must be \code{TRUE}}
 }
 \value{
 Invisibly, the ids of packets that were pulled
 }
 \description{
-Pull a packet (all files) from a location into this archive. This
-will make files available for use as dependencies (e.g., with
-\link{orderly_dependency})
+Pull one or more packets (including all their files) into this
+archive from one or more of your locations. This will make files
+available for use as dependencies (e.g., with
+\link{orderly_dependency}).
 }
 \details{
 The behaviour of this function will vary depending on whether or

--- a/man/orderly_location_pull_packet.Rd
+++ b/man/orderly_location_pull_packet.Rd
@@ -23,6 +23,10 @@ ids directly. Be careful here, your query may pull a lot of data
 remote has!
 }}
 
+\item{options}{Options passed to \link{orderly_search}.
+The option \code{allow_remote} must be \code{TRUE} as otherwise no packet could
+possibly be pulled, so an error is thrown if this is FALSE.}
+
 \item{recursive}{If non-NULL, a logical, indicating if we should
 recursively pull all packets that are referenced by the packets
 specified in \code{id}.  This might copy a lot of data!  If \code{NULL},
@@ -40,10 +44,6 @@ for.  If \code{TRUE}, then we looks in the directory given for \code{root}
 (or the working directory if \code{NULL}) and then up through its
 parents until it finds an \code{.outpack} directory or
 \code{orderly_config.yml}}
-
-\item{search_options}{Options passed to
-\link{orderly_search}. Only the \code{location} option here is
-preseved, as \code{allow_remote} must be \code{TRUE}}
 }
 \value{
 Invisibly, the ids of packets that were pulled

--- a/tests/testthat/test-location-path.R
+++ b/tests/testthat/test-location-path.R
@@ -289,7 +289,7 @@ test_that("push overlapping tree", {
 
   id_base <- create_random_packet(server)
   orderly_location_pull_metadata(root = client) # TODO: should be automatic
-  orderly_location_pull_packet(id_base, "server", root = client)
+  orderly_location_pull_packet(id_base, root = client)
 
   ids <- create_random_packet_chain(client, 3, id_base)
   plan <- orderly_location_push(ids[[3]], "server", client)

--- a/tests/testthat/test-location.R
+++ b/tests/testthat/test-location.R
@@ -416,7 +416,7 @@ test_that("detect and avoid modified files in source repository", {
   ## Corrupt the file in the first id by truncating it:
   file.create(file.path(root$src$path, "archive", "data", id[[1]], "a.rds"))
   expect_message(
-    orderly_location_pull_packet(id[[1]], "src", root = root$dst),
+    orderly_location_pull_packet(id[[1]], root = root$dst),
     sprintf("Rejecting file 'a.rds' in 'data/%s'", id[[1]]))
 
   expect_equal(
@@ -438,10 +438,10 @@ test_that("Do not unpack a packet twice", {
   orderly_location_add("src", "path", list(path = root$src$path),
                        root = root$dst)
   orderly_location_pull_metadata(root = root$dst)
-  orderly_location_pull_packet(id, "src", root = root$dst)
+  orderly_location_pull_packet(id, root = root$dst)
 
   expect_equal(
-    orderly_location_pull_packet(id, "src", root = root$dst),
+    orderly_location_pull_packet(id, root = root$dst),
     character(0))
 })
 
@@ -456,7 +456,7 @@ test_that("Sensible error if packet not known", {
   orderly_location_add("src", "path", list(path = root$src$path),
                        root = root$dst)
   expect_error(
-    orderly_location_pull_packet(id, "src", root = root$dst),
+    orderly_location_pull_packet(id, root = root$dst),
     "Failed to find packet at location 'src': '.+'")
 })
 
@@ -495,8 +495,7 @@ test_that("Can pull a tree recursively", {
                        root = root$dst)
   orderly_location_pull_metadata(root = root$dst)
   expect_equal(
-    orderly_location_pull_packet(id$c, "src", recursive = TRUE,
-                                 root = root$dst),
+    orderly_location_pull_packet(id$c, recursive = TRUE, root = root$dst),
     c(id$a, id$b, id$c))
 
   index <- root$dst$index()
@@ -504,8 +503,7 @@ test_that("Can pull a tree recursively", {
                root$src$index()$unpacked)
 
   expect_equal(
-    orderly_location_pull_packet(id$c, "src", recursive = TRUE,
-                                 root = root$dst),
+    orderly_location_pull_packet(id$c, recursive = TRUE, root = root$dst),
     character(0))
 })
 

--- a/tests/testthat/test-location.R
+++ b/tests/testthat/test-location.R
@@ -212,7 +212,6 @@ test_that("can pull metadata from a file base location", {
   root_upstream <- create_temporary_root(use_file_store = TRUE)
 
   ids <- vcapply(1:3, function(i) create_random_packet(root_upstream$path))
-
   root_downstream <- create_temporary_root(use_file_store = TRUE)
 
   orderly_location_add("upstream", "path", list(path = root_upstream$path),
@@ -747,4 +746,23 @@ test_that("can add a custom outpack location", {
   mockery::expect_called(mock_orderly_location_custom, 1)
   expect_equal(mockery::mock_args(mock_orderly_location_custom)[[1]],
                list(list(driver = "foo::bar", a = 1, b = 2)))
+})
+
+
+test_that("can pull packets as a result of a query", {
+  root <- list()
+  for (name in c("src", "dst")) {
+    root[[name]] <- create_temporary_root(use_file_store = TRUE)
+  }
+  ids <- vcapply(1:3, function(i) {
+    create_random_packet(root$src$path, parameters = list(i = i))
+  })
+  orderly_location_add("src", "path", list(path = root$src$path),
+                       root = root$dst$path)
+  ids_moved <- orderly_location_pull_packet(
+    "parameter:i < 3",
+    name = "data",
+    options = list(pull_metadata = TRUE, allow_remote = TRUE),
+    root = root$dst$path)
+  expect_setequal(ids_moved, ids[1:2])
 })

--- a/tests/testthat/test-location.R
+++ b/tests/testthat/test-location.R
@@ -766,3 +766,20 @@ test_that("can pull packets as a result of a query", {
     root = root$dst$path)
   expect_setequal(ids_moved, ids[1:2])
 })
+
+
+test_that("pull packet sets allow_remote to TRUE if not given", {
+  root <- list()
+  for (name in c("src", "dst")) {
+    root[[name]] <- create_temporary_root()
+  }
+
+  id <- create_random_packet(root$src)
+  orderly_location_add("src", "path", list(path = root$src$path),
+                       root = root$dst)
+  orderly_location_pull_metadata(root = root$dst)
+  expect_error(
+    orderly_location_pull_packet(NULL, options = list(allow_remote = FALSE),
+                                 root = root$dst),
+    "If specifying 'options', 'allow_remote' must be TRUE")
+})

--- a/tests/testthat/test-outpack-packet.R
+++ b/tests/testthat/test-outpack-packet.R
@@ -823,7 +823,7 @@ test_that("can pull in dependency when not found, if requested", {
   path_src_a <- withr::local_tempdir()
   query <- quote(latest(name == "data" && parameter:p > 2))
 
-  p_a <- outpack_packet_start(path_src_a, "example", root = root$a)
+  p_a <- outpack_packet_start(path_src_a, "example", root = root$a$path)
   expect_error(
     outpack_packet_use_dependency(p_a, query, c("data.rds" = "data.rds")),
     paste0("Failed to find packet for query:\n    ",
@@ -844,7 +844,7 @@ test_that("can pull in dependency when not found, if requested", {
   expect_equal(p_a$depends[[1]]$packet, ids[[3]])
 
   path_src_b <- withr::local_tempdir()
-  p_b <- outpack_packet_start(path_src_b, "example", root = root$b)
+  p_b <- outpack_packet_start(path_src_b, "example", root = root$b$path)
   outpack_packet_use_dependency(p_b, query, c("data.rds" = "data.rds"),
                                 search_options = list(pull_metadata = TRUE,
                                                       allow_remote = TRUE))

--- a/tests/testthat/test-outpack-packet.R
+++ b/tests/testthat/test-outpack-packet.R
@@ -294,7 +294,7 @@ test_that("Can add additional data", {
   outpack_packet_add_custom(p, "potato", custom)
   outpack_packet_end(p)
 
-  meta <- outpack_metadata(p$id, root = root)
+  meta <- orderly_metadata(p$id, root = root)
   expect_equal(meta$custom, list(potato = list(a = 1, b = 2)))
 })
 

--- a/tests/testthat/test-outpack-packet.R
+++ b/tests/testthat/test-outpack-packet.R
@@ -294,9 +294,7 @@ test_that("Can add additional data", {
   outpack_packet_add_custom(p, "potato", custom)
   outpack_packet_end(p)
 
-  ## See mrc-3091 - this should be made easier
-  path_metadata <- file.path(root$path, ".outpack", "metadata", p$id)
-  meta <- outpack_metadata_load(path_metadata)
+  meta <- outpack_metadata(p$id, root = root)
   expect_equal(meta$custom, list(potato = list(a = 1, b = 2)))
 })
 

--- a/tests/testthat/test-query-index.R
+++ b/tests/testthat/test-query-index.R
@@ -19,7 +19,7 @@ test_that("index can include only unpacked packets", {
   expect_equal(index_unpacked$index$id, character(0))
 
   for (i in c(x1, x2)) {
-    orderly_location_pull_packet(i, location = "src", root = root$dst)
+    orderly_location_pull_packet(i, root = root$dst)
   }
 
   index <- new_query_index(root$dst, opts_all)

--- a/tests/testthat/test-query-search.R
+++ b/tests/testthat/test-query-search.R
@@ -29,6 +29,15 @@ test_that("can convert into search options", {
                modifyList(orderly_search_options(), list(location = "x")))
   expect_equal(as_orderly_search_options(unclass(opts)),
                opts)
+  expect_equal(as_orderly_search_options(NULL, list(allow_remote = TRUE)),
+               orderly_search_options(allow_remote = TRUE))
+  expect_equal(as_orderly_search_options(list(location = "a"),
+                                         list(allow_remote = TRUE)),
+               orderly_search_options(location = "a", allow_remote = TRUE))
+  expect_equal(as_orderly_search_options(list(allow_remote = FALSE,
+                                              location = "a"),
+                                         list(allow_remote = TRUE)),
+               orderly_search_options(allow_remote = FALSE, location = "a"))
 })
 
 

--- a/tests/testthat/test-query-search.R
+++ b/tests/testthat/test-query-search.R
@@ -278,7 +278,7 @@ test_that("scope and allow_local can be used together to filter query", {
     NA_character_)
 
   for (i in c(x1, y1)) {
-    orderly_location_pull_packet(i, location = "src", root = root$dst)
+    orderly_location_pull_packet(i, root = root$dst)
   }
 
   expect_equal(


### PR DESCRIPTION
Previously just took an id, now it can take a query following the pattern elsewhere. Somewhat more complicated because we need to check the value of the option `allow_remote` to prevent nonsensical requests!