### PR TITLE
mrc-4463: drop location id, name becomes primary key

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -48,7 +48,7 @@ jobs:
       # releases and then we can install and cache against that.
       - name: setup server
         run: |
-          cargo install --git https://github.com/mrc-ide/outpack_server --branch main
+          cargo install --git https://github.com/mrc-ide/outpack_server --branch mrc-4464
 
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:

--- a/.github/workflows/test-coverage.yaml
+++ b/.github/workflows/test-coverage.yaml
@@ -23,7 +23,7 @@ jobs:
 
       - name: setup server
         run: |
-          cargo install --git https://github.com/mrc-ide/outpack_server --branch main
+          cargo install --git https://github.com/mrc-ide/outpack_server --branch mrc-4464
 
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:

--- a/R/location.R
+++ b/R/location.R
@@ -626,16 +626,6 @@ lookup_location_id <- function(name, root) {
 }
 
 
-local_location_id <- function(root) {
-  lookup_location_id(local, root)
-}
-
-
-lookup_location_name <- function(id, root) {
-  root$config$location$name[match(id, root$config$location$id)]
-}
-
-
 location_check_new_name <- function(root, name) {
   if (location_exists(root, name)) {
     stop(sprintf("A location with name '%s' already exists",

--- a/R/location.R
+++ b/R/location.R
@@ -619,7 +619,7 @@ new_location_entry <- function(name, type, args) {
     check_symbol_from_str(args$driver, "args$driver")
   }
 
-  location_id <- paste(as.character(openssl::rand_bytes(4)), collapse = "")
+  location_id <- name
   ## NOTE: make sure this matches the order in config_read
   data_frame(name = name,
              id = location_id,

--- a/R/location.R
+++ b/R/location.R
@@ -223,11 +223,11 @@ orderly_location_pull_metadata <- function(location = NULL, root = NULL,
                                            locate = TRUE) {
   root <- root_open(root, locate = locate, require_orderly = FALSE,
                     call = environment())
-  location_id <- location_resolve_valid(location, root,
-                                        include_local = FALSE,
-                                        allow_no_locations = TRUE)
-  for (id in location_id) {
-    location_pull_metadata(id, root)
+  location_name <- location_resolve_valid(location, root,
+                                          include_local = FALSE,
+                                          allow_no_locations = TRUE)
+  for (name in location_name) {
+    location_pull_metadata(name, root)
   }
 }
 
@@ -313,11 +313,10 @@ orderly_location_pull_packet <- function(..., options = NULL, recursive = NULL,
   ## We could come up with a few heuristics about where to get files
   ## from - see plan_copy_files too for another shot at this that can
   ## then be tidied up.
-  location_id <- location_resolve_valid(options$locations, root,
-                                        include_local = FALSE,
-                                        allow_no_locations = FALSE)
-  plan <- location_build_pull_plan(ids, location_id, root)
-  local_id <- local_location_id(root)
+  location_name <- location_resolve_valid(options$locations, root,
+                                          include_local = FALSE,
+                                          allow_no_locations = FALSE)
+  plan <- location_build_pull_plan(ids, location_name, root)
 
   ## At this point we should really be providing logging about how
   ## many packets, files, etc are being copied.  I've done this as a
@@ -345,7 +344,7 @@ orderly_location_pull_packet <- function(..., options = NULL, recursive = NULL,
     if (!is.null(root$config$core$path_archive)) {
       location_pull_files_archive(root, driver, plan$packet[i])
     }
-    mark_packet_known(plan$packet[i], local_id, hash, Sys.time(), root)
+    mark_packet_known(plan$packet[i], local, hash, Sys.time(), root)
   }
 
   invisible(ids)
@@ -521,7 +520,7 @@ location_resolve_valid <- function(location, root, include_local,
     stop("No suitable location found")
   }
 
-  lookup_location_id(location, root)
+  location
 }
 
 

--- a/R/location.R
+++ b/R/location.R
@@ -615,7 +615,6 @@ new_location_entry <- function(name, type, args) {
 
   ## NOTE: make sure this matches the order in config_read
   data_frame(name = name,
-             id = name,
              type = type,
              args = I(list(args)))
 }

--- a/R/location.R
+++ b/R/location.R
@@ -621,11 +621,6 @@ new_location_entry <- function(name, type, args) {
 }
 
 
-lookup_location_id <- function(name, root) {
-  root$config$location$id[match(name, root$config$location$name)]
-}
-
-
 location_check_new_name <- function(root, name) {
   if (location_exists(root, name)) {
     stop(sprintf("A location with name '%s' already exists",

--- a/R/location_path.R
+++ b/R/location_path.R
@@ -2,19 +2,17 @@ orderly_location_path <- R6::R6Class(
   "orderly_location_path",
 
   private = list(
-    root = NULL,
-    local_id = NULL
+    root = NULL
   ),
 
   public = list(
     initialize = function(path) {
       private$root <- root_open(path, locate = FALSE, require_orderly = FALSE)
-      private$local_id <- local_location_id(private$root)
     },
 
     list = function() {
       dat <- private$root$index()$location
-      dat[dat$location == private$local_id, c("packet", "time", "hash")]
+      dat[dat$location == local, c("packet", "time", "hash")]
     },
 
     metadata = function(packet_ids) {
@@ -22,7 +20,7 @@ orderly_location_path <- R6::R6Class(
       ## shipping results from, then we need to validate that these
       ## ids are all found within our data.
       dat <- private$root$index()$location
-      msg <- setdiff(packet_ids, dat$packet[dat$location == private$local_id])
+      msg <- setdiff(packet_ids, dat$packet[dat$location == local])
       if (length(msg) > 0) {
         stop("Some packet ids not found: ",
              paste(squote(msg), collapse = ", "))
@@ -99,9 +97,8 @@ location_path_import_metadata <- function(str, hash, root) {
   }
 
   writeLines(str, file.path(root$path, ".outpack", "metadata", id))
-  local_id <- local_location_id(root)
   time <- Sys.time()
-  mark_packet_known(id, local_id, hash, time, root)
+  mark_packet_known(id, local, hash, time, root)
 }
 
 

--- a/R/outpack_config.R
+++ b/R/outpack_config.R
@@ -300,7 +300,6 @@ config_read <- function(root_path) {
   ## NOTE: make sure that this matches the order in new_location_entry
   config$location <- data_frame(
     name = vcapply(config$location, "[[", "name"),
-    id = vcapply(config$location, "[[", "id"),
     type = vcapply(config$location, "[[", "type"),
     args = I(lapply(config$location, "[[", "args")))
   if (is.null(config$logging)) {

--- a/R/outpack_helpers.R
+++ b/R/outpack_helpers.R
@@ -154,11 +154,11 @@ plan_copy_files <- function(root, id, there, here) {
 ## We don't want here to necessarily download all of these files; some
 ## might be found locally.
 copy_files_from_remote <- function(id, there, here, dest, overwrite, root) {
-  location_id <- location_resolve_valid(NULL, root,
-                                        include_local = FALSE,
-                                        allow_no_locations = FALSE)
-  plan <- location_build_pull_plan(id, location_id, root)
-  driver <- location_driver(plan$location_id[match(id, plan$packet)], root)
+  location_name <- location_resolve_valid(NULL, root,
+                                          include_local = FALSE,
+                                          allow_no_locations = FALSE)
+  plan <- location_build_pull_plan(id, location_name, root)
+  driver <- location_driver(plan$location[match(id, plan$packet)], root)
 
   meta <- root$metadata(id)
   hash <- meta$files$hash[match(there, meta$files$path)]

--- a/R/outpack_insert.R
+++ b/R/outpack_insert.R
@@ -4,8 +4,6 @@ outpack_insert_packet <- function(path, json, root = NULL) {
   outpack_log_debug(root, "insert", meta$id, "orderly2:::outpack_insert_packet")
   assert_is_directory(path)
 
-  local_id <- local_location_id(root)
-
   hash_algorithm <- root$config$core$hash_algorithm
 
   ## At this point we need to require that 'id' is not known to the
@@ -19,7 +17,7 @@ outpack_insert_packet <- function(path, json, root = NULL) {
   ## appear.
   index <- root$index()
   exists <- any(index$location$packet == id &
-                index$location$location == local_id)
+                index$location$location == local)
   if (exists) {
     stop(sprintf("'%s' has already been added for '%s'", id, local))
   }
@@ -45,7 +43,7 @@ outpack_insert_packet <- function(path, json, root = NULL) {
   ## its own thing.
   hash <- hash_data(json, hash_algorithm)
   time <- Sys.time()
-  mark_packet_known(id, local_id, hash, time, root)
+  mark_packet_known(id, local, hash, time, root)
 
   ## If we were going to add a number in quick succession we could
   ## avoid churn here by not rewriting at every point.
@@ -53,12 +51,12 @@ outpack_insert_packet <- function(path, json, root = NULL) {
 }
 
 
-mark_packet_known <- function(packet_id, location_id, hash, time, root) {
+mark_packet_known <- function(packet_id, location, hash, time, root) {
   dat <- list(schema_version = scalar(outpack_schema_version()),
               packet = scalar(packet_id),
               time = scalar(time_to_num(time)),
               hash = scalar(hash))
-  dest <- file.path(root$path, ".outpack", "location", location_id, packet_id)
+  dest <- file.path(root$path, ".outpack", "location", location, packet_id)
   fs::dir_create(dirname(dest))
   writeLines(to_json(dat, "location"), dest)
 }

--- a/R/outpack_metadata.R
+++ b/R/outpack_metadata.R
@@ -204,8 +204,7 @@ validate_hashes <- function(found, expected) {
 
 get_metadata_hash <- function(packet_id, root) {
   index <- root$index()$location
-  location_id <- local_location_id(root)
-  i <- index$packet == packet_id & index$location == location_id
+  i <- index$packet == packet_id & index$location == local
   hash <- index$hash[i]
   stopifnot(length(hash) == 1)
   hash

--- a/R/query_index.R
+++ b/R/query_index.R
@@ -93,10 +93,10 @@ new_query_index <- function(root, options) {
   metadata <- idx$metadata
 
   if (!is.null(options$location)) {
-    location_id <- location_resolve_valid(options$location, root,
-                                          include_local = TRUE,
-                                          allow_no_locations = FALSE)
-    include <- idx$location$packet[idx$location$location %in% location_id]
+    location <- location_resolve_valid(options$location, root,
+                                       include_local = TRUE,
+                                       allow_no_locations = FALSE)
+    include <- idx$location$packet[idx$location$location %in% location]
     metadata <- metadata[names(metadata) %in% include]
   }
   if (!options$allow_remote) {

--- a/inst/outpack/schema/config.json
+++ b/inst/outpack/schema/config.json
@@ -55,7 +55,7 @@
                         "type": "string"
                     },
                     "id": {
-                        "$ref": "location-id.json"
+                        "type": "string"
                     },
                     "type": {
                         "type": "string"

--- a/inst/outpack/schema/config.json
+++ b/inst/outpack/schema/config.json
@@ -54,9 +54,6 @@
                     "name": {
                         "type": "string"
                     },
-                    "id": {
-                        "type": "string"
-                    },
                     "type": {
                         "type": "string"
                     },
@@ -64,7 +61,7 @@
                         "type": "object"
                     }
                 },
-                "required": ["name", "id", "type", "args"]
+                "required": ["name", "type", "args"]
             }
         }
     },

--- a/tests/testthat/helper-outpack.R
+++ b/tests/testthat/helper-outpack.R
@@ -128,7 +128,7 @@ temp_file <- function() {
 ## Edit an existing configuration to drop the logging section. Hard
 ## without loading the json but this works for now:
 config_remove_logging <- function(path) {
-  fmt <- '{
+  config <- '{
   "schema_version": "0.0.1",
   "core": {
     "path_archive": "archive",
@@ -139,14 +139,14 @@ config_remove_logging <- function(path) {
   "location": [
     {
       "name": "local",
-      "id": "%s",
+      "id": "local",
       "type": "local",
       "args": []
     }
   ]
 }'
   writeLines(
-    sprintf(fmt, local_location_id(root_open(path, FALSE, FALSE))),
+    config,
     file.path(path, ".outpack", "config.json"))
 }
 

--- a/tests/testthat/test-location-path.R
+++ b/tests/testthat/test-location-path.R
@@ -156,27 +156,25 @@ test_that("can detect differences between locations when destination empty", {
 
   files <- lapply(ids, function(id) client$metadata(id)$files$hash)
 
-  location_id <- lookup_location_id("server", client)
-
   ## Simplest case; leaf node not known to the server.
-  plan1 <- location_build_push_plan(ids[[1]], location_id, client)
+  plan1 <- location_build_push_plan(ids[[1]], "server", client)
   expect_setequal(names(plan1), c("packet_id", "files"))
   expect_equal(plan1$packet_id, ids[[1]])
   expect_setequal(plan1$files, files[[1]])
 
   ## Whole tree:
-  plan2 <- location_build_push_plan(ids[[4]], location_id, client)
+  plan2 <- location_build_push_plan(ids[[4]], "server", client)
   expect_setequal(names(plan2), c("packet_id", "files"))
   expect_setequal(plan2$packet_id, ids)
   expect_setequal(plan2$files, unique(unlist(files, FALSE, FALSE)))
 
   ## Same if we use any of our ids explicitly:
   expect_equal(
-    location_build_push_plan(ids, location_id, client),
-    location_build_push_plan(ids[[4]], location_id, client))
+    location_build_push_plan(ids, "server", client),
+    location_build_push_plan(ids[[4]], "server", client))
   expect_equal(
-    location_build_push_plan(ids[c(1, 4)], location_id, client),
-    location_build_push_plan(ids[[4]], location_id, client))
+    location_build_push_plan(ids[c(1, 4)], "server", client),
+    location_build_push_plan(ids[[4]], "server", client))
 })
 
 

--- a/tests/testthat/test-location.R
+++ b/tests/testthat/test-location.R
@@ -71,12 +71,9 @@ test_that("Can rename a location", {
   orderly_location_add("b", "path", list(path = root$b$path), root = root$a)
   expect_setequal(orderly_location_list(root = root$a), c("local", "b"))
 
-  ids <- orderly_config(root$a)$location$id
-
   orderly_location_rename("b", "c", root = root$a)
   expect_setequal(orderly_location_list(root = root$a), c("local", "c"))
-
-  expect_setequal(orderly_config(root$a)$location$id, ids)
+  expect_setequal(orderly_config(root$a)$location$name, c("local", "c"))
 })
 
 
@@ -139,8 +136,8 @@ test_that("Can remove a location", {
                   c("local", "orphan"))
 
   config <- orderly_config(root$a)
-  orphan_id <- config$location$id[config$location$name == "orphan"]
-  expect_equal(root$a$index()$location$location, c(orphan_id))
+  orphan_id <- "orphan"
+  expect_equal(root$a$index()$location$location, orphan_id)
 })
 
 
@@ -164,14 +161,11 @@ test_that("Removing a location orphans packets only from that location", {
 
   # id1 should now be found in both b and c
   index <- root$a$index()
-  config <- orderly_config(root$a)
-  b_id <- config$location$id[config$location$name == "b"]
-  c_id <- config$location$id[config$location$name == "c"]
   expect_equal(index$location$location[index$location$packet == id1],
-               c(b_id, c_id))
+               c("b", "c"))
 
   # id2 should just be found in b
-  expect_equal(index$location$location[index$location$packet == id2], b_id)
+  expect_equal(index$location$location[index$location$packet == id2], "b")
 
   # remove location b
   orderly_location_remove("b", root = root$a)
@@ -179,14 +173,11 @@ test_that("Removing a location orphans packets only from that location", {
                   c("local", "orphan", "c"))
 
   # id1 should now only be found in c
-  config <- orderly_config(root$a)
   index <- root$a$index()
-  expect_equal(index$location$location[index$location$packet == id1], c_id)
+  expect_equal(index$location$location[index$location$packet == id1], "c")
 
   # id2 should be orphaned
-  orphan_id <- config$location$id[config$location$name == "orphan"]
-  expect_equal(index$location$location[index$location$packet == id2], orphan_id)
-
+  expect_equal(index$location$location[index$location$packet == id2], "orphan")
 })
 
 
@@ -735,7 +726,7 @@ test_that("can add a custom outpack location", {
   mock_orderly_location_custom <- mockery::mock("value")
   mockery::stub(location_driver, "orderly_location_custom",
                 mock_orderly_location_custom)
-  expect_equal(location_driver(loc$id, root), "value")
+  expect_equal(location_driver(loc$name, root), "value")
   mockery::expect_called(mock_orderly_location_custom, 1)
   expect_equal(mockery::mock_args(mock_orderly_location_custom)[[1]],
                list(list(driver = "foo::bar", a = 1, b = 2)))

--- a/tests/testthat/test-location.R
+++ b/tests/testthat/test-location.R
@@ -230,8 +230,7 @@ test_that("can pull metadata from a file base location", {
 
   expect_s3_class(index$location, "data.frame")
   expect_setequal(index$location$packet, ids)
-  expect_equal(index$location$location,
-               rep(lookup_location_id("upstream", root_downstream), 3))
+  expect_equal(index$location$location, rep("upstream", 3))
 })
 
 
@@ -273,12 +272,12 @@ test_that("pull metadata from subset of locations", {
     ids[[name]] <- vcapply(1:3, function(i) create_random_packet(root[[name]]))
   }
 
-  location_id <- lookup_location_id(c("x", "y", "z"), root$a)
+  location_name <- c("x", "y", "z")
 
   orderly_location_pull_metadata(c("x", "y"), root = root$a)
   index <- root$a$index()
   expect_setequal(names(index$metadata), c(ids$x, ids$y))
-  expect_equal(index$location$location, rep(location_id[1:2], each = 3))
+  expect_equal(index$location$location, rep(location_name[1:2], each = 3))
   expect_equal(index$metadata[ids$x],
                root$x$index()$metadata)
   expect_equal(index$metadata[ids$y],
@@ -287,7 +286,7 @@ test_that("pull metadata from subset of locations", {
   orderly_location_pull_metadata(root = root$a)
   index <- root$a$index()
   expect_setequal(names(index$metadata), c(ids$x, ids$y, ids$z))
-  expect_equal(index$location$location, rep(location_id, each = 3))
+  expect_equal(index$location$location, rep(location_name, each = 3))
   expect_equal(index$metadata[ids$z],
                root$z$index()$metadata)
 })
@@ -347,8 +346,7 @@ test_that("Can pull metadata through chain of locations", {
   expect_equal(nrow(index$location), 3)
   expect_equal(index$location$packet, c(id1, id1, id2))
 
-  expect_equal(index$location$location,
-               lookup_location_id(c("b", "c", "c"), root$d))
+  expect_equal(index$location$location, c("b", "c", "c"))
 })
 
 
@@ -517,22 +515,18 @@ test_that("Can resolve locations", {
     }
   }
 
-  location_id <- set_names(
-    lookup_location_id(c("a", "b", "c", "d", "local"), root$dst),
-    c("a", "b", "c", "d", "local"))
-
   expect_equal(
     location_resolve_valid(NULL, root$dst, FALSE, FALSE),
-    lookup_location_id(c("a", "b", "c", "d"), root$dst))
+    c("a", "b", "c", "d"))
   expect_equal(
     location_resolve_valid(NULL, root$dst, TRUE, FALSE),
-    lookup_location_id(c("local", "a", "b", "c", "d"), root$dst))
+    c("local", "a", "b", "c", "d"))
   expect_equal(
     location_resolve_valid(c("a", "b", "local", "d"), root$dst, FALSE, FALSE),
-    lookup_location_id(c("a", "b", "d"), root$dst))
+    c("a", "b", "d"))
   expect_equal(
     location_resolve_valid(c("a", "b", "local", "d"), root$dst, TRUE, FALSE),
-    lookup_location_id(c("a", "b", "local", "d"), root$dst))
+    c("a", "b", "local", "d"))
 
   expect_error(
     location_resolve_valid(TRUE, root$dst, TRUE, FALSE),

--- a/tests/testthat/test-location.R
+++ b/tests/testthat/test-location.R
@@ -595,8 +595,7 @@ test_that("Can filter locations", {
   ids <- unique(c(ids_a, ids_b, ids_c, ids_d))
   expected <- function(ids, location_name) {
     data_frame(packet = ids,
-               location_id = lookup_location_id(location_name, root$dst),
-               location_name = location_name)
+               location = location_name)
   }
   locs <- function(location) {
     location_resolve_valid(location, root$dst,

--- a/tests/testthat/test-outpack-packet.R
+++ b/tests/testthat/test-outpack-packet.R
@@ -32,9 +32,7 @@ test_that("Can run a basic packet", {
   expect_true(file.exists(path_metadata))
   outpack_schema("metadata")$validate(path_metadata)
 
-  location_id <- root$config$location$id
-
-  path_location <- file.path(path, ".outpack", "location", location_id, id)
+  path_location <- file.path(path, ".outpack", "location", "local", id)
   expect_true(file.exists(path_location))
   outpack_schema("location")$validate(path_location)
 


### PR DESCRIPTION
I was starting to move the schemas over, but realised that we never use this bit of indirection - and I don't even remember why it is here.

I think that the idea was that we could track back from a packet to the original location where it was generated (like a fingerprint) but that never made it through to the rest of the package. So now we just let the name be the primary key, which is what git does anyway.

From the tests you can see that the fallout is very minor - we really weren't using this "feature" at all for anything

The workflows should get the outpack_server branch pin updated before merge