### PR TITLE
Explicitly pass environment to context

### DIFF
--- a/R/context.R
+++ b/R/context.R
@@ -29,43 +29,6 @@ orderly_context <- function(envir) {
 }
 
 
-## This is a real trick, and is only used in the case where the report
-## is being run interactively, and in that case the correct thing is
-## *almost certainly* the global environment, as the user has to do
-## some tricks to stop that being the case; for example running
-##
-## > source("orderly.R", local = TRUE)
-##
-## We want to find the environment that corresponds to the top level
-## environment for orderly; that will be the one that called the
-## plugin function. So we'll have a stack of frames (corresponding to
-## the environments on the call stack) with *parents* that look like
-## this, outermost first:
-##
-## - (anything else)
-## - (calling environment) <-- this is what we're looking for
-## - (plugin)
-## - (orderly2; orderly_plugin_context)
-## - (orderly2; from orderly_context)
-## - (orderly2; from orderly_environment)
-##
-## so we loop down the stack looking for the first call to a function
-## in the plugin package, then take the frame *above* that.
-##
-## When we want this for a non-plugin case (i.e., the caller is in
-## orderly2) then we just need to pass name = "orderly2" here
-orderly_environment <- function(name) {
-  frames <- sys.frames()
-  for (i in seq_along(frames)[-1]) {
-    if (environmentName(parent.env(frames[[i]])) == name) {
-      return(frames[[i - 1]])
-    }
-  }
-  ## This error should never surface if the plugin is configured correctly
-  stop("Could not determine calling environment safely - please report")
-}
-
-
 ##' Fetch information about the actively running report.  This allows
 ##' you to reflect information about your report back as part of the
 ##' report, for example embedding the current report id, or

--- a/R/context.R
+++ b/R/context.R
@@ -1,4 +1,4 @@
-orderly_context <- function() {
+orderly_context <- function(envir) {
   p <- get_active_packet()
   is_active <- !is.null(p)
   if (is_active) {
@@ -17,7 +17,6 @@ orderly_context <- function() {
     config <- root_open(root,
                         locate = FALSE,
                         require_orderly = TRUE)$config$orderly
-    envir <- orderly_environment("orderly2")
     src <- path
     parameters <- current_orderly_parameters(src, envir)
     name <- basename(path)
@@ -94,7 +93,7 @@ orderly_environment <- function(name) {
 ##'     - `as`: the filename used locally
 ##' @export
 orderly_run_info <- function() {
-  ctx <- orderly_context()
+  ctx <- orderly_context(rlang::caller_env())
 
   id <- ctx$packet$id %||% NA_character_
   name <- ctx$name

--- a/R/metadata.R
+++ b/R/metadata.R
@@ -249,7 +249,7 @@ orderly_dependency <- function(name, query, files) {
   assert_scalar_character(name)
   assert_scalar_character(query)
 
-  ctx <- orderly_context()
+  ctx <- orderly_context(rlang::caller_env())
   subquery <- NULL
   query <- orderly_query(query, name = name, subquery = subquery)
   search_options <- as_orderly_search_options(ctx$search_options)
@@ -303,7 +303,7 @@ static_orderly_dependency <- function(args) {
 ##' @export
 orderly_shared_resource <- function(...) {
   files <- validate_shared_resource(list(...))
-  ctx <- orderly_context()
+  ctx <- orderly_context(rlang::caller_env())
 
   files <- copy_shared_resource(ctx$root, ctx$path, ctx$config, files)
   if (ctx$is_active) {

--- a/R/plugin.R
+++ b/R/plugin.R
@@ -155,10 +155,6 @@ orderly_plugin_context <- function(name, envir) {
   ctx$config <- ctx$config$plugins[[name]]$config
   ## No direct access to the full packet
   ctx$packet <- NULL
-  ## Correct environment in the interactive case:
-  if (!ctx$is_active) {
-    ctx$envir <- orderly_environment(name)
-  }
   ctx
 }
 

--- a/R/plugin.R
+++ b/R/plugin.R
@@ -109,6 +109,13 @@ orderly_plugin <- function(config, serialise, cleanup, schema) {
 ##'
 ##' @param name Name of the plugin
 ##'
+##' @param envir The environment of the calling function. You can
+##'   typically pass `parent.frame()` (or `rlang::caller_env()`) here
+##'   if the function calling `orderly_plugin_context()` is the
+##'   function that would be called by a user. This argument only has
+##'   an effect in interactive use (where `envir` is almost certainly
+##'   the global environment).
+##'
 ##' @return A list with elements:
 ##'
 ##' * `is_active`: a logical, indicating if we're running under
@@ -139,9 +146,9 @@ orderly_plugin <- function(config, serialise, cleanup, schema) {
 ##' @seealso [orderly2::orderly_plugin_register],
 ##' [orderly2::orderly_plugin_add_metadata]
 ##' @export
-orderly_plugin_context <- function(name) {
+orderly_plugin_context <- function(name, envir) {
   assert_scalar_character(name)
-  ctx <- orderly_context()
+  ctx <- orderly_context(envir)
   check_plugin_enabled(name, ctx$config)
   ## Narrower view on configuration - can only see the config for the
   ## plugin itself:

--- a/man/orderly_plugin_context.Rd
+++ b/man/orderly_plugin_context.Rd
@@ -4,10 +4,17 @@
 \alias{orderly_plugin_context}
 \title{Fetch plugin context}
 \usage{
-orderly_plugin_context(name)
+orderly_plugin_context(name, envir)
 }
 \arguments{
 \item{name}{Name of the plugin}
+
+\item{envir}{The environment of the calling function. You can
+typically pass \code{parent.frame()} (or \code{rlang::caller_env()}) here
+if the function calling \code{orderly_plugin_context()} is the
+function that would be called by a user. This argument only has
+an effect in interactive use (where \code{envir} is almost certainly
+the global environment).}
 }
 \value{
 A list with elements:

--- a/tests/testthat/examples/depends-query/orderly.R
+++ b/tests/testthat/examples/depends-query/orderly.R
@@ -1,0 +1,10 @@
+orderly2::orderly_parameters(a = NULL, b = NULL, c = NULL)
+orderly2::orderly_dependency(
+  "parameters",
+  paste("latest(parameter:a == this:a &&",
+        "parameter:b == this:b &&",
+        "parameter:c == this:c)"),
+  c(input.rds = "data.rds"))
+orderly2::orderly_artefact("Processed data", "result.rds")
+d <- readRDS("input.rds")
+saveRDS(lapply(d, function(x) x * 2), "result.rds")

--- a/tests/testthat/plugins/example.random/R/random.R
+++ b/tests/testthat/plugins/example.random/R/random.R
@@ -1,5 +1,5 @@
 numbers <- function(as, n) {
-  ctx <- orderly2::orderly_plugin_context("example.random")
+  ctx <- orderly2::orderly_plugin_context("example.random", parent.frame())
   x <- ctx$config$generator(n)
   ctx$envir[[as]] <- x
   info <- list(as = as, mean = mean(x), variance = var(x))

--- a/tests/testthat/test-plugin.R
+++ b/tests/testthat/test-plugin.R
@@ -99,13 +99,6 @@ test_that("error if packet uses non-configured plugin", {
 })
 
 
-test_that("error if environment not found", {
-  expect_error(
-    orderly_environment("unknown.package"),
-    "Could not determine calling environment safely - please report")
-})
-
-
 test_that("run cleanup on exit", {
   skip_if_not_installed("mockery")
   clear_plugins()

--- a/tests/testthat/test-run.R
+++ b/tests/testthat/test-run.R
@@ -138,7 +138,7 @@ test_that("can run orderly with parameters, without orderly", {
 })
 
 
-test_that("can ruin orderly with parameters, without orderly, globally", {
+test_that("can run orderly with parameters, without orderly, globally", {
   path <- test_prepare_orderly_example(c("parameters", "depends-query"))
   id <- orderly_run("parameters", parameters = list(a = 10, b = 20, c = 30),
                     envir = new.env(), root = path)

--- a/tests/testthat/test-run.R
+++ b/tests/testthat/test-run.R
@@ -138,6 +138,20 @@ test_that("can run orderly with parameters, without orderly", {
 })
 
 
+test_that("can ruin orderly with parameters, without orderly, globally", {
+  path <- test_prepare_orderly_example(c("parameters", "depends-query"))
+  id <- orderly_run("parameters", parameters = list(a = 10, b = 20, c = 30),
+                    envir = new.env(), root = path)
+  path_src <- file.path(path, "src", "depends-query")
+  envir <- list2env(list(a = 10, b = 20, c = 30), parent = globalenv())
+  withr::with_dir(path_src,
+                  sys.source("orderly.R", envir))
+  path_rds <- file.path(path_src, "result.rds")
+  expect_true(file.exists(path_rds))
+  expect_equal(readRDS(path_rds), list(a = 20, b = 40, c = 60))
+})
+
+
 test_that("Can run simple case with dependency", {
   path <- test_prepare_orderly_example(c("data", "depends"))
   envir1 <- new.env()


### PR DESCRIPTION
This simplifies some weird code, and will be more reliable in practice I think.

I've tried to come up with a failing test, that does not work on main, but can't do so - it's easy to trigger the failure interactively though...