### PR TITLE
Log dependency resolution, throwing appropriate errors

### DIFF
--- a/R/metadata.R
+++ b/R/metadata.R
@@ -253,10 +253,13 @@ orderly_dependency <- function(name, query, files) {
   query <- orderly_query(query, name = name, subquery = subquery)
   search_options <- as_orderly_search_options(ctx$search_options)
   if (ctx$is_active) {
-    outpack_packet_use_dependency(ctx$packet, query, files,
-                                  search_options = search_options,
-                                  envir = ctx$envir,
-                                  overwrite = TRUE)
+    id <- outpack_packet_use_dependency(ctx$packet, query, files,
+                                        search_options = search_options,
+                                        envir = ctx$envir,
+                                        overwrite = TRUE)
+
+    msg <- sprintf("%s @ %s (%s)", name, id, format(query))
+    outpack_log_info(ctx$packet, "depends", msg, "orderly2::orderly_dependency")
   } else {
     orderly_copy_files(query, files = files, dest = ctx$path, overwrite = TRUE,
                        parameters = ctx$parameters, options = search_options,

--- a/R/outpack_helpers.R
+++ b/R/outpack_helpers.R
@@ -106,7 +106,12 @@ orderly_copy_files <- function(..., files, dest, overwrite = TRUE,
         i = "Did you forget latest()?"))
     }
     if (length(id) == 0 || is.na(id)) {
-      cli::cli_abort("Query returned 0 results")
+      explanation <- orderly_query_explain(..., options = options,
+                                           envir = envir, root = root)
+      cli::cli_abort(
+        c("Query returned 0 results",
+          i = "See 'rlang::last_error()$explanation' for details"),
+        explanation = explanation)
     }
   }
 

--- a/R/outpack_packet.R
+++ b/R/outpack_packet.R
@@ -198,14 +198,13 @@ outpack_packet_use_dependency <- function(packet, query, files,
                        options = search_options,
                        root = packet$root)
   if (is.na(id)) {
-    ## TODO: this is where we would want to consider explaining what
-    ## went wrong; because that comes with a cost we should probably
-    ## control this behind some options. We also would want to return
-    ## some classed error here to help with formatting and handling
-    ## the error. In particular we definitely want to allow for
-    ## cycling through allow_remote and location in addition to
-    ## near misses on parameters etc.
-    stop(sprintf("Failed to find packet for query:\n    %s", format(query)))
+    explanation <- orderly_query_explain(
+      query, parameters = packet$parameters, envir = envir,
+      options = search_options, root = packet$root)
+    cli::cli_abort(
+      c("Failed to find packet for query '{format(query)}'",
+        i = "See 'rlang::last_error()$explanation' for details"),
+      explanation = explanation)
   }
 
   needs_pull <- search_options$allow_remote &&

--- a/R/outpack_packet.R
+++ b/R/outpack_packet.R
@@ -235,7 +235,7 @@ outpack_packet_use_dependency <- function(packet, query, files,
 
   outpack_packet_file_mark(packet, result$here, "immutable")
 
-  invisible()
+  invisible(id)
 }
 
 

--- a/R/query.R
+++ b/R/query.R
@@ -173,7 +173,9 @@ query_parse_add_scope <- function(expr_parsed, scope) {
   scoped_functions <- list("latest", "single")
   expr <- expr_parsed$expr
 
-  if (expr_parsed$type %in% scoped_functions) {
+  if (expr_parsed$type == "empty") {
+    expr_parsed <- parsed_scope
+  } else if (expr_parsed$type %in% scoped_functions) {
     fn <- deparse(expr[[1]])
     ## Include scope inside the top level function call
     if (length(expr_parsed$args) == 0) {

--- a/R/query_deparse.R
+++ b/R/query_deparse.R
@@ -63,6 +63,9 @@ deparse_query <- function(x, subquery, envir) {
   if (length(x) == 1) {
     return(deparse_single(x))
   }
+  if (is.null(x)) {
+    return("NULL")
+  }
 
   fn <- as.character(x[[1]])
   args <- x[-1]

--- a/R/run.R
+++ b/R/run.R
@@ -215,7 +215,9 @@ orderly_run <- function(name, parameters = NULL, envir = NULL,
     str_trace <- format_rlang_trace(e$trace, colours = FALSE)
     outpack_log_info(p, "trace", str_trace, caller, console = FALSE)
     orderly_packet_cleanup_failure(p)
-    cli::cli_abort("Failed to run report", parent = e)
+    cli::cli_abort("Failed to run report",
+                   parent = e,
+                   explanation = e$explanation)
   }
 
   id

--- a/tests/testthat/test-outpack-helpers.R
+++ b/tests/testthat/test-outpack-helpers.R
@@ -110,5 +110,8 @@ test_that("require a single id for search", {
     orderly_copy_files(name = "missing", files = c(here = "there"),
                        dest = dst, root = root),
     "Query returned 0 results")
-  expect_null(err$body)
+  expect_equal(err$body,
+               c(i = "See 'rlang::last_error()$explanation' for details"))
+  expect_equal(err$explanation,
+               orderly_query_explain(NULL, name = "missing", root = root))
 })

--- a/tests/testthat/test-outpack-packet.R
+++ b/tests/testthat/test-outpack-packet.R
@@ -636,11 +636,15 @@ test_that("error if dependency cannot be resolved", {
   path_src <- temp_file()
   fs::dir_create(path_src)
   p <- outpack_packet_start(path_src, "example", root = root)
-  expect_error(
+  err <- expect_error(
     outpack_packet_use_dependency(p, quote(latest(name == "data")),
                                   c("data.rds" = "data.rds")),
-    'Failed to find packet for query:\n    latest(name == "data")',
+    "Failed to find packet for query 'latest(name == \"data\")'",
     fixed = TRUE)
+  expect_equal(err$body,
+               c(i = "See 'rlang::last_error()$explanation' for details"))
+  expect_equal(err$explanation,
+               orderly_query_explain("latest", name = "data", root = root))
 })
 
 
@@ -670,8 +674,8 @@ test_that("can pull in dependency from specific location", {
   expect_error(
     outpack_packet_use_dependency(p, query, c("data.rds" = "data.rds"),
                                   search_options = options),
-    paste0("Failed to find packet for query:\n    ",
-           'latest(name == "data" && parameter:p > 2)'),
+    paste("Failed to find packet for query",
+          "'latest(name == \"data\" && parameter:p > 2)'"),
     fixed = TRUE)
 
   for (id in ids$x) {
@@ -711,8 +715,8 @@ test_that("can pull in dependency when not found, if requested", {
   p_a <- outpack_packet_start(path_src_a, "example", root = root$a$path)
   expect_error(
     outpack_packet_use_dependency(p_a, query, c("data.rds" = "data.rds")),
-    paste0("Failed to find packet for query:\n    ",
-           'latest(name == "data" && parameter:p > 2)'),
+    paste("Failed to find packet for query",
+          "'latest(name == \"data\" && parameter:p > 2)'"),
     fixed = TRUE)
 
   expect_length(root$a$index$data()$metadata, 0)

--- a/tests/testthat/test-query.R
+++ b/tests/testthat/test-query.R
@@ -260,3 +260,12 @@ test_that("validate inputs to orderly_query", {
     orderly_query("latest", list(a = 1)),
     "'name' must be character")
 })
+
+
+test_that("can construct query without expression", {
+  res <- orderly_query(NULL)
+  expect_equal(format(res), "NULL")
+
+  res <- orderly_query(NULL, name = "foo")
+  expect_equal(format(res), 'name == "foo"')
+})

--- a/tests/testthat/test-run.R
+++ b/tests/testthat/test-run.R
@@ -1000,3 +1000,20 @@ test_that("can use quote for queries queries", {
   id2 <- orderly_run("depends", root = path)
   expect_equal(orderly_metadata(id2, root = path)$depends$packet, id1[[2]])
 })
+
+
+test_that("can describe misses for dependencies", {
+  path <- test_prepare_orderly_example(c("data", "depends"))
+  envir <- new.env()
+  err <- expect_error(
+    orderly_run("depends", root = path, envir = envir),
+    "Failed to run report")
+  expect_equal(
+    unname(err$parent$message),
+    "Failed to find packet for query 'latest(name == \"data\")'")
+  expect_equal(
+    err$parent$body,
+    c(i = "See 'rlang::last_error()$explanation' for details"))
+  expect_s3_class(err$parent$explanation, "orderly_query_explain")
+  expect_identical(err$explanation, err$parent$explanation)
+})

--- a/vignettes/dependencies.Rmd
+++ b/vignettes/dependencies.Rmd
@@ -175,7 +175,7 @@ The error suggests running `rlang::last_error()$explanation` for more informatio
 rlang::last_error()$explanation
 ```
 
-This is an `orderly_query_explain` object, which tries to come up with reasons why your query might not have matched; we'll expand this in future so let us know what you might like to see.
+This is an `orderly_query_explain` object, which tries to come up with reasons why your query might not have matched; we'll expand this in the future so let us know what you might like to see.
 
 This tells you that your query can be decomposed into two subqueries `A` (the match against the parameter `cyl` being 9000), which matched no packets and `B` (the match against the packet name being `data`), which matched 3 packets. If each subquery matched packets but some *pairs* don't then it will try and guide you towards problematic pairs.
 

--- a/vignettes/dependencies.Rmd
+++ b/vignettes/dependencies.Rmd
@@ -92,7 +92,7 @@ id1 <- orderly2::orderly_run("data", root = path, logging_console = FALSE)
 id2 <- orderly2::orderly_run("analysis", root = path)
 ```
 
-When we look at the metadata for the packet created from the `analysis` report, we can see it has used `r id1` as its dependency:
+When we look at the metadata for the packet created from the `analysis` report, we can see it has used `r inline(id1)` as its dependency:
 
 ```{r}
 orderly2::orderly_metadata(id2, root = path)$depends
@@ -157,6 +157,52 @@ Here the query `latest(parameter:cyl == this:cyl)` says "find the most recent pa
 
 ```{r}
 orderly2::orderly_run("analysis", list(cyl = 4), root = path)
+```
+
+## Interpreting errors
+
+If your query fails to resolve a candidate it will error:
+
+```{r, error = TRUE}
+orderly2::orderly_run("analysis", list(cyl = 9000), root = path)
+```
+
+The error message here tries to be fairly self explanatory; we have failed to find a packet that satisfies our query` latest(parameter:cyl == this:cyl && name == "data")`; note that the report name `data` has become part of this query, so there are two conditions being matched on.
+
+The error suggests running `rlang::last_error()$explanation` for more information, which we can do:
+
+```{r}
+rlang::last_error()$explanation
+```
+
+This is an `orderly_query_explain` object, which tries to come up with reasons why your query might not have matched; we'll expand this in future so let us know what you might like to see.
+
+This tells you that your query can be decomposed into two subqueries `A` (the match against the parameter `cyl` being 9000), which matched no packets and `B` (the match against the packet name being `data`), which matched 3 packets. If each subquery matched packets but some *pairs* don't then it will try and guide you towards problematic pairs.
+
+You can also ask `orderly2` to explain any query for you:
+
+```{r}
+orderly2::orderly_query_explain(
+  quote(latest(parameter:cyl == 9000)), name = "data", root = path)
+```
+
+If you save this object you can explore it in more detail:
+
+```{r}
+explanation <- orderly2::orderly_query_explain(
+  quote(latest(parameter:cyl == 9000)), name = "data", root = path)
+explanation$parts$B
+```
+
+(this would have worked with `rlang::last_error()$explanation$parts$A` too).
+
+You can also use `orderly2::orderly_metadata_extract` to work out what values you might have looked for:
+
+```{r}
+orderly2::orderly_metadata_extract(
+  name = "data",
+  extract = c(cyl = "parameters.cyl is number"),
+  root = path)
 ```
 
 ## Filtering candidates in other ways


### PR DESCRIPTION
This PR does a few related things:

* Log to screen and log.json the resolution of dependencies (orderly1 did this and it was useful)
* Use the query explanation as part of the error message
* Fix a bug in deparsing a `NULL` query