### PR TITLE
Validate metadata responses returned by locations

### DIFF
--- a/R/location.R
+++ b/R/location.R
@@ -230,7 +230,7 @@ orderly_location_pull_metadata <- function(location = NULL, root = NULL,
                                           include_local = FALSE,
                                           allow_no_locations = TRUE)
   for (name in location_name) {
-    location_pull_metadata(name, root)
+    location_pull_metadata(name, root, environment())
   }
 }
 
@@ -420,20 +420,40 @@ orderly_location_custom <- function(args) {
 }
 
 
-location_pull_metadata <- function(location_name, root) {
+location_pull_metadata <- function(location_name, root, call) {
   index <- root$index$data()
   driver <- location_driver(location_name, root)
 
   known_there <- driver$list()
 
   ## Things we've never heard of from any location:
-  new_id_metadata <- setdiff(known_there$packet, names(index$metadata))
-  if (length(new_id_metadata) > 0) {
-    metadata <- driver$metadata(new_id_metadata)
+  is_new <- !(known_there$packet %in% names(index$metadata))
+
+  if (any(is_new)) {
+    metadata <- driver$metadata(known_there$packet[is_new])
+    id_new <- known_there$packet[is_new]
+    expected_hash <- known_there$hash[is_new]
     path_metadata <- file.path(root$path, ".outpack", "metadata")
     fs::dir_create(path_metadata)
-    filename <- file.path(path_metadata, new_id_metadata)
+    filename <- file.path(path_metadata, id_new)
     for (i in seq_along(metadata)) {
+      ## Ensure that the server is shipping data that matches what it
+      ## says it is, if this is the first time we've seen this.
+      ##
+      ## This is not actually actionable, and it's not clear what can
+      ## be done at present. The user should probably remove this
+      ## location I think.
+      hash_validate_data(
+        metadata[[i]], expected_hash[[i]],
+        sprintf("metadata for '%s' from '%s'", id_new[i], location_name),
+        c(x = paste("This is bad news, I'm afraid. Your location is sending",
+                    "data that does not match the hash it says it does.",
+                    "Please let us know how this might have happened."),
+          i = paste("Probably all you can do at this point is remove this",
+                    "location from your configuration by running",
+                    sprintf('orderly2::orderly_location_remove("%s")',
+                            location_name))),
+        call)
       writeLines(metadata[[i]], filename[[i]])
     }
   }

--- a/R/location_http.R
+++ b/R/location_http.R
@@ -21,8 +21,8 @@ orderly_location_http <- R6::R6Class(
     metadata = function(packet_ids) {
       ret <- vcapply(packet_ids, function(id) {
         tryCatch(
-          private$client$get(sprintf("/metadata/%s/text", id),
-                             parse_json = FALSE),
+          trimws(private$client$get(sprintf("/metadata/%s/text", id),
+                                    parse_json = FALSE)),
           outpack_http_client_error = function(e) {
             if (e$code == 404) {
               e$message <- sprintf("Some packet ids not found: '%s'", id)

--- a/R/outpack_hash.R
+++ b/R/outpack_hash.R
@@ -49,7 +49,7 @@ hash_validate <- function(found, expected, name, body, call) {
     ## aaa0 given
     ## bcde want
     cli::cli_abort(c("Hash of {name} does not match!",
-                     i = "{.strong {found}} found",
+                     x = "{.strong {found}} found",
                      i = "{.strong {expected}} want",
                      body),
                    call = call)

--- a/R/outpack_hash.R
+++ b/R/outpack_hash.R
@@ -26,21 +26,33 @@ hash_parse <- function(hash) {
 }
 
 
-hash_validate_file <- function(path, expected) {
-  hash_validate(rehash(path, hash_file, expected), expected, squote(path))
+hash_validate_file <- function(path, expected, body = NULL, call = NULL) {
+  hash_validate(rehash(path, hash_file, expected), expected, squote(path),
+                body, call)
 }
 
 
-hash_validate_data <- function(data, expected, name = deparse(substitute(x))) {
-  hash_validate(rehash(data, hash_data, expected), expected, name)
+hash_validate_data <- function(data, expected, name = deparse(substitute(x)),
+                               body = NULL, call = NULL) {
+  hash_validate(rehash(data, hash_data, expected), expected, name,
+                body, call)
 }
 
 
-hash_validate <- function(found, expected, name) {
+hash_validate <- function(found, expected, name, body, call) {
   if (found != expected) {
-    stop(sprintf(
-      "Hash of %s does not match:\n - expected: %s\n - found:    %s",
-      name, expected, found))
+    ## These are hard to print well because the sha256 hash that we
+    ## probably have consumes 71 characters, plus 2 for the bullet.
+    ##
+    ## 7         8
+    ## 01234567890
+    ## aaa0 given
+    ## bcde want
+    cli::cli_abort(c("Hash of {name} does not match!",
+                     i = "{.strong {found}} found",
+                     i = "{.strong {expected}} want",
+                     body),
+                   call = call)
   }
   invisible(found)
 }

--- a/tests/testthat/helper-outpack.R
+++ b/tests/testthat/helper-outpack.R
@@ -3,11 +3,13 @@
 options(outpack.schema_validate = TRUE)
 
 
-create_random_packet <- function(root, name = "data", parameters = NULL) {
+create_random_packet <- function(root, name = "data", parameters = NULL,
+                                 id = NULL) {
   src <- fs::dir_create(tempfile())
   on.exit(unlink(src, recursive = TRUE))
   saveRDS(runif(10), file.path(src, "data.rds"))
-  p <- outpack_packet_start(src, name, parameters = parameters, root = root)
+  p <- outpack_packet_start(src, name, parameters = parameters, id = id,
+                            root = root)
   outpack_packet_end(p)
   p$id
 }

--- a/tests/testthat/test-location.R
+++ b/tests/testthat/test-location.R
@@ -786,7 +786,7 @@ test_that("handle metadata where the hash does not match reported", {
   expect_equal(
     unname(err$message),
     sprintf("Hash of metadata for '%s' from 'server' does not match!", id))
-  expect_equal(names(err$body), c("i", "i", "x", "i"))
+  expect_equal(names(err$body), c("x", "i", "x", "i"))
   expect_match(err$body[[3]], "This is bad news")
   expect_match(err$body[[4]], "remove this location")
 })

--- a/tests/testthat/test-outpack-hash.R
+++ b/tests/testthat/test-outpack-hash.R
@@ -34,8 +34,10 @@ test_that("can validate hash", {
     withr::with_dir(dirname(tmp),
                     hash_validate_file(basename(tmp), expected_data)),
     sprintf("Hash of '%s' does not match", basename(tmp)))
-  expect_error(
+  err <- expect_error(
     hash_validate_data(data, expected_file, "thing"),
-    sprintf("Hash of thing does not match:\n - expected: %s\n - found:    %s",
-            expected_file, expected_data))
+    "Hash of thing does not match!")
+  expect_equal(names(err$body), c("x", "i"))
+  expect_match(err$body[[1]], sprintf("%s.+found", expected_data))
+  expect_match(err$body[[2]], sprintf("%s.+want", expected_file))
 })


### PR DESCRIPTION
This PR validates three things that I was aware that we relied on, but was avoiding checking carefully:

* a location may not return multiple bits of metadata for the same packet
* the hash that the location says metadata has must match the metadata provided
* the hash that metadata has must match any previously imported bits of metadata

Big long errors in response on all of these, but with some luck they'll never surface to the user