### PR TITLE
Fix corner case when implicitly copying

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: orderly2
 Title: Orderly Next Generation
-Version: 1.99.2
+Version: 1.99.3
 Authors@R: c(person("Rich", "FitzJohn", role = c("aut", "cre"),
                     email = "rich.fitzjohn@gmail.com"),
              person("Robert", "Ashton", role = "aut"),

--- a/R/util.R
+++ b/R/util.R
@@ -117,6 +117,9 @@ vcapply <- function(X, FUN, ...) { # nolint
 
 ## TODO: also replace copy_shared with this
 expand_dirs <- function(paths, workdir) {
+  if (length(paths) == 0) {
+    return(character())
+  }
   withr::local_dir(workdir)
   i <- is_directory(paths)
   if (any(i)) {

--- a/tests/testthat/test-run.R
+++ b/tests/testthat/test-run.R
@@ -994,3 +994,17 @@ test_that("can describe misses for dependencies", {
   expect_s3_class(err$parent$explanation, "orderly_query_explain")
   expect_identical(err$explanation, err$parent$explanation)
 })
+
+
+test_that("can run example with artefacts and no resources", {
+  path <- test_prepare_orderly_example("implicit")
+  path_src <- file.path(path, "src", "implicit", "orderly.R")
+  file.create(file.path(dirname(path_src), "mygraph.png"))
+
+  envir <- new.env()
+  ## previously this errored
+  prepend_lines(path_src, 'orderly2::orderly_artefact("plot", "mygraph.png")')
+  id <- orderly_run_quietly("implicit", root = path, envir = envir)
+  expect_true(file.exists(
+    file.path(path, "archive", "implicit", id, "mygraph.png")))
+})


### PR DESCRIPTION
A few things have to align here:

* the task has no resources
* it does have an artefact declared
* that artefact already exists in the *source* directory

In that case, the copy detection fails with a useless error:

```
>   id <- orderly_run("implicit", root = path, envir = envir)
Error in enc2utf8(path) : argument is not a character vector
```

This PR lets that situation just work.
