### PR TITLE
Return something useful from orderly_resource

### DIFF
--- a/R/metadata.R
+++ b/R/metadata.R
@@ -257,20 +257,20 @@ orderly_dependency <- function(name, query, files) {
   query <- orderly_query(query, name = name, subquery = subquery)
   search_options <- as_orderly_search_options(ctx$search_options)
   if (ctx$is_active) {
-    id <- outpack_packet_use_dependency(ctx$packet, query, files,
-                                        search_options = search_options,
-                                        envir = ctx$envir,
-                                        overwrite = TRUE)
-    cli::cli_alert_info(
-      "Depending on {.pkg {name}} @ {.code {id}} (via {format(query)})")
+    res <- outpack_packet_use_dependency(ctx$packet, query, files,
+                                         search_options = search_options,
+                                         envir = ctx$envir,
+                                         overwrite = TRUE)
   } else {
-    ## TODO: also echo here I think
-    orderly_copy_files(query, files = files, dest = ctx$path, overwrite = TRUE,
-                       parameters = ctx$parameters, options = search_options,
-                       envir = ctx$envir, root = ctx$root)
+    res <- orderly_copy_files(
+      query, files = files, dest = ctx$path, overwrite = TRUE,
+      parameters = ctx$parameters, options = search_options,
+      envir = ctx$envir, root = ctx$root)
   }
 
-  invisible()
+  cli::cli_alert_info(
+    "Depending on {.pkg {res$name}} @ {.code {res$id}} (via {format(query)})")
+  invisible(res)
 }
 
 
@@ -311,11 +311,10 @@ static_orderly_dependency <- function(args) {
 ##'   copy. The name will be the destination filename, while the value
 ##'   is the filename within the shared resource directory.
 ##'
-##' @return Invisibly, a character vector of the names of files that
-##'   were copied over (the name that they will have in the running
-##'   report, not the source name). As for
-##'   [orderly2::orderly_resource], do not rely on the ordering where
-##'   directory expansion was performed.
+##' @return Invisibly, a data.frame with columns `here` (the fileames
+##'   as as copied into the running packet) and `there` (the filenames
+##'   within `shared/`).  As for [orderly2::orderly_resource], do not
+##'   rely on the ordering where directory expansion was performed.
 ##'
 ##' @export
 orderly_shared_resource <- function(...) {
@@ -329,7 +328,7 @@ orderly_shared_resource <- function(...) {
       rbind(ctx$packet$orderly2$shared_resources, files)
   }
 
-  invisible(files$here)
+  invisible(files)
 }
 
 

--- a/R/metadata.R
+++ b/R/metadata.R
@@ -311,7 +311,12 @@ static_orderly_dependency <- function(args) {
 ##'   copy. The name will be the destination filename, while the value
 ##'   is the filename within the shared resource directory.
 ##'
-##' @return Undefined
+##' @return Invisibly, a character vector of the names of files that
+##'   were copied over (the name that they will have in the running
+##'   report, not the source name). As for
+##'   [orderly2::orderly_resource], do not rely on the ordering where
+##'   directory expansion was performed.
+##'
 ##' @export
 orderly_shared_resource <- function(...) {
   files <- validate_shared_resource(list(...), environment())
@@ -324,7 +329,7 @@ orderly_shared_resource <- function(...) {
       rbind(ctx$packet$orderly2$shared_resources, files)
   }
 
-  invisible()
+  invisible(files$here)
 }
 
 

--- a/R/metadata.R
+++ b/R/metadata.R
@@ -143,7 +143,9 @@ static_orderly_description <- function(args) {
 ##'
 ##' @param files Any number of names of files
 ##'
-##' @return Undefined
+##' @return Invisibly, a character vector of resources included by the
+##'   call. Don't rely on the order of these files if they are
+##'   expanded from directories, as this is likely platform dependent.
 ##'
 ##' @export
 orderly_resource <- function(files) {
@@ -157,6 +159,7 @@ orderly_resource <- function(files) {
   p <- get_active_packet()
   if (is.null(p)) {
     assert_file_exists(files)
+    files_expanded <- expand_dirs(files, ".")
   } else {
     src <- p$orderly2$src
     assert_file_exists(files, workdir = src)
@@ -170,7 +173,7 @@ orderly_resource <- function(files) {
     p$orderly2$resources <- c(p$orderly2$resources, files_expanded)
   }
 
-  invisible()
+  invisible(files_expanded)
 }
 
 

--- a/R/outpack_helpers.R
+++ b/R/outpack_helpers.R
@@ -116,6 +116,7 @@ orderly_copy_files <- function(..., files, dest, overwrite = TRUE,
   }
 
   plan <- plan_copy_files(root, id, files$from, files$to)
+  name <- outpack_metadata_core(id, root)$name
 
   tryCatch(
     file_export(root, id, plan$there, plan$here, dest, overwrite),
@@ -144,7 +145,7 @@ orderly_copy_files <- function(..., files, dest, overwrite = TRUE,
                              environment())
     })
 
-  invisible(plan)
+  invisible(list(id = id, name = name, files = plan))
 }
 
 

--- a/R/outpack_packet.R
+++ b/R/outpack_packet.R
@@ -208,12 +208,12 @@ outpack_packet_use_dependency <- function(packet, query, files,
   depends <- list(
     packet = id,
     query = query_str,
-    files = data_frame(here = result$here, there = result$there))
+    files = result$files)
   packet$depends <- c(packet$depends, list(depends))
 
-  outpack_packet_file_mark(packet, result$here, "immutable")
+  outpack_packet_file_mark(packet, result$files$here, "immutable")
 
-  invisible(id)
+  invisible(result)
 }
 
 

--- a/R/read.R
+++ b/R/read.R
@@ -92,10 +92,10 @@ orderly_read_r <- function(path) {
 orderly_read_expr <- function(e, nms) {
   ## We count the following things as top level:
   ##
-  ## orderly2::orderly_fn()
-  ## orderly_fn()
-  ## a <- orderly2::orderly_fn()
-  ## a <- orderly_fn()
+  ## > orderly2::orderly_fn()
+  ## > orderly_fn()
+  ## > a <- orderly2::orderly_fn()
+  ## > a <- orderly_fn()
   if (is_assignment(e)) {
     return(orderly_read_expr(e[[3]], nms))
   } else if (is_orderly_ns_call(e)) {
@@ -105,7 +105,7 @@ orderly_read_expr <- function(e, nms) {
       return(list(is_orderly = TRUE, name = nm, expr = e))
     }
   } else {
-    if (is.recursive(e) && is.name(e)) {
+    if (is.recursive(e) && is.name(e[[1]])) {
       nm <- deparse(e[[1]])
       if (nm %in% nms) {
         return(list(is_orderly = TRUE, name = nm, expr = e))

--- a/R/util.R
+++ b/R/util.R
@@ -13,6 +13,14 @@ is_call <- function(x, name) {
 }
 
 
+is_assignment <- function(x) {
+  if (!(is.recursive(x) && is.name(x[[1]]))) {
+    return(FALSE)
+  }
+  as.character(x[[1]]) %in% c("<-", "=", "<<-")
+}
+
+
 is_orderly_ns_call <- function(x) {
   is.recursive(x) && is_call(x[[1]], "::") &&
     as.character(x[[1]][[2]]) == "orderly2"

--- a/man/orderly_resource.Rd
+++ b/man/orderly_resource.Rd
@@ -10,7 +10,9 @@ orderly_resource(files)
 \item{files}{Any number of names of files}
 }
 \value{
-Undefined
+Invisibly, a character vector of resources included by the
+call. Don't rely on the order of these files if they are
+expanded from directories, as this is likely platform dependent.
 }
 \description{
 Declare that a file, or group of files, are an orderly

--- a/man/orderly_shared_resource.Rd
+++ b/man/orderly_shared_resource.Rd
@@ -12,11 +12,10 @@ copy. The name will be the destination filename, while the value
 is the filename within the shared resource directory.}
 }
 \value{
-Invisibly, a character vector of the names of files that
-were copied over (the name that they will have in the running
-report, not the source name). As for
-\link{orderly_resource}, do not rely on the ordering where
-directory expansion was performed.
+Invisibly, a data.frame with columns \code{here} (the fileames
+as as copied into the running packet) and \code{there} (the filenames
+within \verb{shared/}).  As for \link{orderly_resource}, do not
+rely on the ordering where directory expansion was performed.
 }
 \description{
 Copy shared resources into a packet directory. You can use this to

--- a/man/orderly_shared_resource.Rd
+++ b/man/orderly_shared_resource.Rd
@@ -12,7 +12,11 @@ copy. The name will be the destination filename, while the value
 is the filename within the shared resource directory.}
 }
 \value{
-Undefined
+Invisibly, a character vector of the names of files that
+were copied over (the name that they will have in the running
+report, not the source name). As for
+\link{orderly_resource}, do not rely on the ordering where
+directory expansion was performed.
 }
 \description{
 Copy shared resources into a packet directory. You can use this to

--- a/tests/testthat/test-outpack-helpers.R
+++ b/tests/testthat/test-outpack-helpers.R
@@ -2,8 +2,8 @@ test_that("can copy files from outpack", {
   root <- create_temporary_root(use_file_store = TRUE)
   id <- create_random_packet(root)
   dst <- temp_file()
-  orderly_copy_files(id, files = c("incoming.rds" = "data.rds"), dest = dst,
-                     root = root)
+  res <-  orderly_copy_files(
+    id, files = c("incoming.rds" = "data.rds"), dest = dst, root = root)
   expect_equal(dir(dst), "incoming.rds")
   expect_identical(
     readRDS(file.path(dst, "incoming.rds")),

--- a/tests/testthat/test-outpack-packet.R
+++ b/tests/testthat/test-outpack-packet.R
@@ -564,7 +564,7 @@ test_that("can depend based on a simple query", {
     p$depends[[1]],
     list(packet = id$b[[3]],
          query = "latest()",
-         files = data.frame(here = "1.rds", there = "data.rds")))
+         files = data.frame(there = "data.rds", here = "1.rds")))
 
   query <- orderly_query("latest(parameter:i < 3)", name = "a")
   outpack_packet_use_dependency(p, query, c("2.rds" = "data.rds"))
@@ -572,7 +572,7 @@ test_that("can depend based on a simple query", {
     p$depends[[2]],
     list(packet = id$a[[2]],
          query = 'latest(parameter:i < 3 && name == "a")',
-         files = data.frame(here = "2.rds", there = "data.rds")))
+         files = data.frame(there = "data.rds", here = "2.rds")))
 })
 
 
@@ -771,8 +771,8 @@ test_that("can pull in directories", {
   p2 <- outpack_packet_start_quietly(path_src2, "b", root = root)
   outpack_packet_use_dependency(p2, 'latest(name == "a")', c(d = "data/"))
   expect_equal(p2$depends[[1]]$files,
-               data_frame(here = file.path("d", letters[1:6]),
-                          there = file.path("data", letters[1:6])))
+               data_frame(there = file.path("data", letters[1:6]),
+                          here = file.path("d", letters[1:6])))
 })
 
 

--- a/tests/testthat/test-read.R
+++ b/tests/testthat/test-read.R
@@ -69,3 +69,45 @@ test_that("read dependency", {
                                    query = "latest",
                                    files = quote(files))))
 })
+
+
+test_that("can parse expressions that might be interesting", {
+  nms <- c("orderly_a", "orderly_b")
+
+  expect_equal(
+    orderly_read_expr(quote(orderly2::orderly_a(x, y)), nms),
+    list(is_orderly = TRUE,
+         name = "orderly_a",
+         expr = quote(orderly2::orderly_a(x, y))))
+  expect_equal(
+    orderly_read_expr(quote(z <- orderly2::orderly_a(x, y)), nms),
+    list(is_orderly = TRUE,
+         name = "orderly_a",
+         expr = quote(orderly2::orderly_a(x, y))))
+  ## Can't use quote(a = expr) here or we fail on matching
+  expect_equal(
+    orderly_read_expr(parse(text = "z = orderly2::orderly_a(x, y)")[[1]], nms),
+    list(is_orderly = TRUE,
+         name = "orderly_a",
+         expr = quote(orderly2::orderly_a(x, y))))
+
+  expect_equal(
+    orderly_read_expr(quote(orderly_a(x, y)), nms),
+    list(is_orderly = TRUE,
+         name = "orderly_a",
+         expr = quote(orderly_a(x, y))))
+  expect_equal(
+    orderly_read_expr(z <- quote(orderly_a(x, y)), nms),
+    list(is_orderly = TRUE,
+         name = "orderly_a",
+         expr = quote(orderly_a(x, y))))
+
+  expect_equal(
+    orderly_read_expr(quote(orderly2::orderly_c(x, y)), nms),
+    list(is_orderly = FALSE,
+         expr = quote(orderly2::orderly_c(x, y))))
+  expect_equal(
+    orderly_read_expr(quote(f(a, b, c)), nms),
+    list(is_orderly = FALSE,
+         expr = quote(f(a, b, c))))
+})


### PR DESCRIPTION
As requested by @sangeetabhatia03, this PR makes the result of special in-report functions more useful:

* `orderly_resource`: returns the computed set of resources (accounting for any directory expansion)
* `orderly_shared_resource`: data.frame of mapping of old file to new file
* `orderly_dependency` - id, name and mapping of old to new file

@lmhaile is needing the mapping for `orderly_dependency`, so best get that in at the same time

I can't see much interesting to return from `orderly_strict_mode`, `orderly_description`, `orderly_parameters` or `orderly_artefact`