### PR TITLE
Deorphan packets when re-found via pull

### DIFF
--- a/R/query_index.R
+++ b/R/query_index.R
@@ -95,6 +95,7 @@ new_query_index <- function(root, options) {
   if (!is.null(options$location)) {
     location <- location_resolve_valid(options$location, root,
                                        include_local = TRUE,
+                                       include_orphan = FALSE,
                                        allow_no_locations = FALSE)
     include <- idx$location$packet[idx$location$location %in% location]
     metadata <- metadata[names(metadata) %in% include]

--- a/man/orderly_location_add.Rd
+++ b/man/orderly_location_add.Rd
@@ -35,8 +35,11 @@ Nothing
 }
 \description{
 Add a new location - a place where other packets might be found
-and pulled into your local archive.  Currently only file-based
-locations are supported.
+and pulled into your local archive.  Currently only file and http
+based locations are supported, with limited support for custom
+locations. Note that adding a location does \emph{not} pull metadata
+from it, you need to call
+\link{orderly_location_pull_metadata} first.
 }
 \details{
 We currently support two types of locations - \code{path}, which points

--- a/man/orderly_location_remove.Rd
+++ b/man/orderly_location_remove.Rd
@@ -26,6 +26,7 @@ parents until it finds an \code{.outpack} directory or
 Nothing
 }
 \description{
-Remove an existing location. Any packets from this location
-will now be associated with the 'orphan' location instead.
+Remove an existing location. Any packets from this location and
+not known elsewhere will now be associated with the 'orphan'
+location instead.
 }


### PR DESCRIPTION
Old issue being addressed here.

This PR adds logic for detecting if we can de-orphan packets if they are re-found anywhere. Doing this also exposed a logic error that pulling metadata after ending up with orphan packets threw an error because we tried to use the orphan location!