### PR TITLE
Add helper to check git status

### DIFF
--- a/R/gitignore.R
+++ b/R/gitignore.R
@@ -35,26 +35,29 @@
 ##' @export
 orderly_gitignore_update <- function(name, root = NULL, locate = TRUE) {
   root <- root_open(root, locate, require_orderly = TRUE, call = environment())
+  do_orderly_gitignore_update(name, root, environment())
+}
+
+## Separate inned function that avoids opening the root, we need this
+## to break a circular dependency as we sometimes call this function
+## while openning the root.
+do_orderly_gitignore_update <- function(name, root, call) {
   assert_scalar_character(name)
 
   if (name == "(root)") {
     path <- ".gitignore"
     value <- gitignore_content_root(root)
   } else {
-    validate_orderly_directory(name, root, environment())
+    validate_orderly_directory(name, root, call)
     path <- file.path("src", name, ".gitignore")
     value <- gitignore_content_src(name, root)
   }
-
-  ## TODO (mrc-4447): check that none of these are _already_ in git,
-  ## and offer help towards fixing this.
 
   if (gitignore_update_file(root$path, path, value)) {
     cli::cli_alert_success("Wrote '{path}'")
   }
   invisible(TRUE)
 }
-
 
 gitignore_content_root <- function(root) {
   c(".outpack",

--- a/R/root.R
+++ b/R/root.R
@@ -275,9 +275,7 @@ root_check_git <- function(root, call) {
     }
   }
 
-  if (!all(gert::git_ignore_path_is_ignored(file.path(root$path, special)))) {
-    orderly_gitignore_update("(root)", root)
-  }
+  do_orderly_gitignore_update("(root)", root)
 
   fs::dir_create(dirname(path_ok))
   fs::file_create(path_ok)

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -11,6 +11,7 @@ articles:
       - introduction
       - dependencies
       - collaboration
+      - troubleshooting
 
   - title: Advanced topics
     navbar: Advanced topics

--- a/inst/WORDLIST
+++ b/inst/WORDLIST
@@ -11,6 +11,7 @@ R's
 Rstudio's
 SQLite
 SharePoint
+StackOverflow
 WIP
 YAML
 arg

--- a/tests/testthat/helper-outpack.R
+++ b/tests/testthat/helper-outpack.R
@@ -132,8 +132,10 @@ temp_file <- function() {
 
 
 helper_add_git <- function(path) {
-  ## Note that the git repo is in the src, not in the outpack root
   gert::git_init(path)
+  if (file.exists(file.path(path, ".outpack"))) {
+    suppressMessages(orderly_gitignore_update("(root)", path))
+  }
   gert::git_add(".", repo = path)
   user <- "author <author@example.com>"
   sha <- gert::git_commit("initial", author = user, committer = user,

--- a/tests/testthat/test-root.R
+++ b/tests/testthat/test-root.R
@@ -91,7 +91,9 @@ test_that("can error with instructions if files are added to git", {
   fs::file_delete(file.path(root$path, ".outpack", "r", "git_ok"))
 
   gert::git_add(".", repo = root$path)
-  gert::git_commit("add everything", repo = root$path)
+  user <- "author <author@example.com>"
+  gert::git_commit("add everything", author = user, committer = user,
+                   repo = root$path)
   err <- expect_error(root_check_git(root, NULL),
                       "Detected \\d+ outpack files committed to git")
   expect_false(file.exists(file.path(root$path, ".outpack", "r", "git_ok")))

--- a/vignettes/troubleshooting.Rmd
+++ b/vignettes/troubleshooting.Rmd
@@ -23,8 +23,7 @@ orderly2::orderly_run("data", root = path)
 gert::git_init(path)
 gert::git_add(".", repo = path)
 user <- "author <author@example.com>"
-sha <- gert::git_commit("initial", author = user, committer = user,
-                        repo = path)
+gert::git_commit("initial", author = user, committer = user, repo = path)
 ```
 
 ```{r, error = TRUE}

--- a/vignettes/troubleshooting.Rmd
+++ b/vignettes/troubleshooting.Rmd
@@ -57,7 +57,7 @@ The rest of this section discusses how you might permanently fix the issue.
 
 ## I don't care about my history at all
 
-This is the case if you have just started a project, and are not yet collaborating on it with anyone else (or if that person is willing to reclone their sources).  The simplest thing to do is:
+This is the case if you have just started a project, and are not yet collaborating on it with anyone else (or if that person is willing to re-clone their sources).  The simplest thing to do is:
 
 1. Delete the `.git` directory entirely
 2. Run `orderly2::orderly_gitignore_update("(root)")` to set up a reasonable `.gitignore` that will prevent this situation happening again

--- a/vignettes/troubleshooting.Rmd
+++ b/vignettes/troubleshooting.Rmd
@@ -15,6 +15,46 @@ If you were directed here, it is probably because you have ended up with these f
 
 We have now put in guard rails to try and prevent this happening, but it could still happen to you if you modify the `.gitignore` file or force-add files for example.
 
+Once you are in this situation, `orderly2` will shout at you:
+
+```{r, include = FALSE}
+path <- orderly2::orderly_example("default")
+orderly2::orderly_run("data", root = path)
+gert::git_init(path)
+gert::git_add(".", repo = path)
+user <- "author <author@example.com>"
+sha <- gert::git_commit("initial", author = user, committer = user,
+                        repo = path)
+```
+
+```{r, error = TRUE}
+orderly2::orderly_run("data", root = path)
+```
+
+which may have directed you to this very page.  If you just want to continue working anyway, then run the suggested command:
+
+```{r}
+options(orderly_git_error_is_warning = TRUE)
+```
+
+after which things will work with a warning the first time that session:
+
+```{r}
+orderly2::orderly_run("data", root = path)
+```
+
+subsequent calls will not display the warning:
+
+```{r}
+orderly2::orderly_run("data", root = path)
+```
+
+```{r, include = FALSE}
+options(orderly_git_error_is_warning = FALSE)
+```
+
+The rest of this section discusses how you might permanently fix the issue.
+
 ## I don't care about my history at all
 
 This is the case if you have just started a project, and are not yet collaborating on it with anyone else (or if that person is willing to reclone their sources).  The simplest thing to do is:

--- a/vignettes/troubleshooting.Rmd
+++ b/vignettes/troubleshooting.Rmd
@@ -1,0 +1,58 @@
+---
+title: "Troubleshooting"
+output: rmarkdown::html_vignette
+vignette: >
+  %\VignetteIndexEntry{Troubleshooting}
+  %\VignetteEngine{knitr::rmarkdown}
+  %\VignetteEncoding{UTF-8}
+---
+
+# Outpack files accidentally committed to git
+
+As discussed in [the orderly introduction](/orderly2/articles/introduction.html#interaction-with-version-control), you do not want to commit any files from `.outpack/`, `drafts/` or `archive/` (if used) to git as this will create all sorts of problems down the line.
+
+If you were directed here, it is probably because you have ended up with these files in git and want to undo this situation. The least painful way depends on your situation.
+
+We have now put in guard rails to try and prevent this happening, but it could still happen to you if you modify the `.gitignore` file or force-add files for example.
+
+## I don't care about my history at all
+
+This is the case if you have just started a project, and are not yet collaborating on it with anyone else (or if that person is willing to reclone their sources).  The simplest thing to do is:
+
+1. Delete the `.git` directory entirely
+2. Run `orderly2::orderly_gitignore_update("(root)")` to set up a reasonable `.gitignore` that will prevent this situation happening again
+3. Run `git add .` to add everything back in (review this with `git status` to make sure you're happy)
+4. Run `git commit -m "Initial commit"` to create a single commit that contains all the files in currently in your repo *with no history*, and also with no `.outpack` files
+
+If you have previously pushed this repo to GitHub or similar then you will need to set that up again
+
+5. `git remote add origin https://github.com/user/repo` (replacing `user/repo` with your path, or using `git@github.com:user/repo` if you use ssh to talk with GitHub)
+6. `git branch -M main` assuming you are using `main` for your default branch, which is now most common
+7. `git push --force -u origin main`
+
+Note that this is **destructive** and will require coordination with any collaborators as you have changed history.
+
+## I just want this to go away and nothing I have committed is very large
+
+If you do care about your history, but you also have only committed a few files (e.g., you have committed files from `.outpack/` which are small but not a large 100MB file in `archive/` that is preventing you [pushing to GitHub](https://docs.github.com/en/repositories/working-with-files/managing-large-files/about-large-files-on-github)) then you could just delete the offending files from git without updating the history, or affecting your local copies.
+
+1. Run `git rm --cached .outpack` (repeating with `draft` and `archive` as needed)
+2. Run `orderly2::orderly_gitignore_update("(root)")` to set up a reasonable `.gitignore` that will prevent this situation happening again
+3. Run `git add .gitignore` to also stage this
+4. Run `git commit -m "Delete unwanted outpack files"`
+
+You can then push this without any issues.
+
+## I care about my history but want this stuff gone
+
+If you are working on a branch, and the unwanted files were committed on that branch, the simplest thing to do is to copy the changes you have made somewhere safe, create a new branch against the current `main` and copy those changes over there. You could do this somewhat automatically by generating and applying a patch:
+
+```
+git diff -- src > changes.patch
+git checkout main
+git checkout -b changes-attempt2
+git apply changes.patch
+git push -u origin changes-attempt2
+```
+
+If the unwanted files have been committed onto your default branch, then you will have to do some potentially gory history rewriting. See [this StackOverflow question](https://stackoverflow.com/questions/10067848/remove-folder-and-its-contents-from-git-githubs-history), the [git docs](https://git-scm.com/docs/git-filter-branch#_warning) and [the currently recommended tool for doing this](https://github.com/newren/git-filter-repo/). Good luck!


### PR DESCRIPTION
Checks that files are not incorrectly added to git, and throws a gigantic error that points at a big blob of docs for fixing things.