### PR TITLE
Be relaxed about the task name

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: orderly2
 Title: Orderly Next Generation
-Version: 1.99.4
+Version: 1.99.5
 Authors@R: c(person("Rich", "FitzJohn", role = c("aut", "cre"),
                     email = "rich.fitzjohn@gmail.com"),
              person("Robert", "Ashton", role = "aut"),

--- a/R/cleanup.R
+++ b/R/cleanup.R
@@ -113,7 +113,7 @@ orderly_cleanup_status <- function(name = NULL, root = NULL, locate = TRUE) {
       ## This situation would be very odd, just disallow it
       cli::cli_abort("If 'root' is given explicitly, 'name' is required")
     }
-    validate_orderly_directory(name, root, environment())
+    name <- validate_orderly_directory(name, root, environment())
     path <- file.path(root$path, "src", name)
     root <- root$path
   }

--- a/R/gitignore.R
+++ b/R/gitignore.R
@@ -48,7 +48,7 @@ do_orderly_gitignore_update <- function(name, root, call) {
     path <- ".gitignore"
     value <- gitignore_content_root(root)
   } else {
-    validate_orderly_directory(name, root, call)
+    name <- validate_orderly_directory(name, root, call)
     path <- file.path("src", name, ".gitignore")
     value <- gitignore_content_src(name, root)
   }

--- a/R/run.R
+++ b/R/run.R
@@ -83,7 +83,9 @@
 ##'
 ##' @title Run a report
 ##'
-##' @param name Name of the report to run
+##' @param name Name of the report to run. Any leading `./` `src/` or
+##'   trailing `/` path parts will be removed (e.g., if added by
+##'   autocomplete).
 ##'
 ##' @param parameters Parameters passed to the report. A named list of
 ##'   parameters declared in the `orderly.yml`.  Each parameter

--- a/R/run.R
+++ b/R/run.R
@@ -129,7 +129,7 @@
 orderly_run <- function(name, parameters = NULL, envir = NULL, echo = TRUE,
                         search_options = NULL, root = NULL, locate = TRUE) {
   root <- root_open(root, locate, require_orderly = TRUE, call = environment())
-  validate_orderly_directory(name, root, environment())
+  name <- validate_orderly_directory(name, root, environment())
 
   envir <- envir %||% .GlobalEnv
   assert_is(envir, "environment")
@@ -487,6 +487,9 @@ orderly_packet_add_metadata <- function(p) {
 
 validate_orderly_directory <- function(name, root, call) {
   assert_scalar_character(name)
+
+  re <- "^(./)*(src/)?(.+?)/?$"
+  name <- sub(re, "\\3", name)
   if (!file_exists(file.path(root$path, "src", name, "orderly.R"))) {
     src <- file.path(root$path, "src", name)
     err <- sprintf("Did not find orderly report '%s'", name)
@@ -512,6 +515,8 @@ validate_orderly_directory <- function(name, root, call) {
                               root$path))
     cli::cli_abort(err, call = call)
   }
+
+  name
 }
 
 

--- a/man/orderly_run.Rd
+++ b/man/orderly_run.Rd
@@ -15,7 +15,9 @@ orderly_run(
 )
 }
 \arguments{
-\item{name}{Name of the report to run}
+\item{name}{Name of the report to run. Any leading \verb{./} \verb{src/} or
+trailing \code{/} path parts will be removed (e.g., if added by
+autocomplete).}
 
 \item{parameters}{Parameters passed to the report. A named list of
 parameters declared in the \code{orderly.yml}.  Each parameter

--- a/tests/testthat/test-run.R
+++ b/tests/testthat/test-run.R
@@ -923,6 +923,53 @@ test_that("validation of orderly directories", {
 })
 
 
+test_that("strip extraneous path components from orderly path", {
+  path <- test_prepare_orderly_example(character())
+  root <- root_open(path, FALSE, TRUE)
+
+  fs::dir_create(file.path(path, "src", "example_a"))
+  file.create(file.path(path, "src", "example_a", "orderly.R"))
+
+  expect_equal(validate_orderly_directory("example_a", root),
+               "example_a")
+  expect_equal(validate_orderly_directory("src/example_a", root),
+               "example_a")
+  expect_equal(validate_orderly_directory("./src/example_a", root),
+               "example_a")
+  expect_equal(validate_orderly_directory("./example_a", root),
+               "example_a")
+  expect_equal(validate_orderly_directory("example_a/", root),
+               "example_a")
+  expect_equal(validate_orderly_directory("src/example_a/", root),
+               "example_a")
+  expect_equal(validate_orderly_directory("./src/example_a/", root),
+               "example_a")
+  expect_equal(validate_orderly_directory("./example_a/", root),
+               "example_a")
+
+  ## Pathalogical case:
+  fs::dir_create(file.path(path, "src", "src"))
+  file.create(file.path(path, "src", "src", "orderly.R"))
+
+  expect_equal(validate_orderly_directory("src", root),
+               "src")
+  expect_equal(validate_orderly_directory("src/src", root),
+               "src")
+  expect_equal(validate_orderly_directory("./src/src", root),
+               "src")
+  expect_equal(validate_orderly_directory("./src", root),
+               "src")
+  expect_equal(validate_orderly_directory("src/", root),
+               "src")
+  expect_equal(validate_orderly_directory("src/src/", root),
+               "src")
+  expect_equal(validate_orderly_directory("./src/src/", root),
+               "src")
+  expect_equal(validate_orderly_directory("./src/", root),
+               "src")
+})
+
+
 test_that("can rename dependencies programmatically", {
   path <- test_prepare_orderly_example("data")
   envir1 <- new.env()


### PR DESCRIPTION
This PR does some light cleanup of the task/report name passed through to the functions

* `orderly_run`
* `orderly_cleanup`
* `orderly_cleanup_status`
* `orderly_gitignore_update`

We strip any leading `./` parts, leading `src/` and trailing `/` - see the tests for the massive number of ways that we can now spell a task name

As requested by @sangeetabhatia03