### PR TITLE
Basic interface to extract graph metadata

### DIFF
--- a/R/graph.R
+++ b/R/graph.R
@@ -8,16 +8,21 @@ orderly_graph_packets <- function(from = NULL, to = NULL,
 
   metadata <- root$index$data()$metadata
   if (!is.null(from)) {
-    dat <- graph_packets_from(from, metadata)
+    if (is.null(metadata[[from]])) {
+      cli::cli_abort("Packet '{from}' does not exist for 'from'")
+    }
+    dat <- graph_packets_from(from, metadata, environment())
   } else {
-    dat <- graph_packets_to(to, metadata)
+    if (is.null(metadata[[to]])) {
+      cli::cli_abort("Packet '{to}' does not exist for 'to'")
+    }
+    dat <- graph_packets_to(to, metadata, environment())
   }
-
   dat
 }
 
 
-graph_packets_to <- function(to, metadata) {
+graph_packets_to <- function(to, metadata, call) {
   validate_outpack_id(to)
   packets <- to
   edges <- list()
@@ -69,5 +74,5 @@ graph_edges_to_df <- function(edges) {
     from = unlist_character(lapply(edges, "[[", "from")),
     to = unlist_character(lapply(edges, "[[", "to")),
     query = unlist_character(lapply(edges, "[[", "query")),
-    files = I(unname(lapply(edges, "[[", "files"))))
+    files = I(unname(unlist(lapply(edges, "[[", "files"), FALSE))))
 }

--- a/R/graph.R
+++ b/R/graph.R
@@ -1,0 +1,73 @@
+orderly_graph_packets <- function(from = NULL, to = NULL,
+                                  root = NULL, locate = FALSE) {
+  root <- root_open(root, locate = locate, require_orderly = FALSE,
+                    call = environment())
+  if (is.null(from) == is.null(to)) {
+    cli::cli_abort("Exactly one of 'from' and 'to' must be given")
+  }
+
+  metadata <- root$index$data()$metadata
+  if (!is.null(from)) {
+    dat <- graph_packets_from(from, metadata)
+  } else {
+    dat <- graph_packets_to(to, metadata)
+  }
+
+  dat
+}
+
+
+graph_packets_to <- function(to, metadata) {
+  validate_outpack_id(to)
+  packets <- to
+  edges <- list()
+  i <- 0L
+  while (i < length(packets)) {
+    i <- i + 1L
+    p <- packets[[i]]
+    depends <- metadata[[p]]$depends
+    if (nrow(depends) > 0) {
+      depends$from <- depends$packet
+      depends$to <- p
+      edges[[p]] <- depends
+      packets <- union(packets, depends$packet)
+    }
+  }
+  edges <- graph_edges_to_df(edges)
+  list(from = NULL, to = to, packets = sort(packets), edges = edges)
+}
+
+
+graph_packets_from <- function(from, metadata) {
+  validate_outpack_id(from)
+  uses <- build_packet_uses(lapply(metadata, "[[", "depends"))
+  packets <- from
+  edges <- list()
+  i <- 0L
+  while (i < length(packets)) {
+    i <- i + 1L
+    p <- packets[[i]]
+    p_used_by <- uses[[p]]$packet
+    if (length(p_used_by) > 0) {
+      for (j in p_used_by) {
+        depends <- metadata[[j]]$depends
+        depends <- depends[depends$packet == p, ]
+        depends$from <- p
+        depends$to <- j
+        edges[[length(edges) + 1]] <- depends
+      }
+      packets <- union(packets, p_used_by)
+    }
+  }
+  edges <- graph_edges_to_df(edges)
+  list(from = from, to = NULL, packets = sort(packets), edges = edges)
+}
+
+
+graph_edges_to_df <- function(edges) {
+  data_frame(
+    from = unlist_character(lapply(edges, "[[", "from")),
+    to = unlist_character(lapply(edges, "[[", "to")),
+    query = unlist_character(lapply(edges, "[[", "query")),
+    files = I(unname(lapply(edges, "[[", "files"))))
+}

--- a/R/graph.R
+++ b/R/graph.R
@@ -11,12 +11,12 @@ orderly_graph_packets <- function(from = NULL, to = NULL,
     if (is.null(metadata[[from]])) {
       cli::cli_abort("Packet '{from}' does not exist for 'from'")
     }
-    dat <- graph_packets_from(from, metadata, environment())
+    dat <- graph_packets_from(from, metadata)
   } else {
     if (is.null(metadata[[to]])) {
       cli::cli_abort("Packet '{to}' does not exist for 'to'")
     }
-    dat <- graph_packets_to(to, metadata, environment())
+    dat <- graph_packets_to(to, metadata)
   }
   dat
 }
@@ -70,9 +70,16 @@ graph_packets_from <- function(from, metadata) {
 
 
 graph_edges_to_df <- function(edges) {
-  data_frame(
-    from = unlist_character(lapply(edges, "[[", "from")),
-    to = unlist_character(lapply(edges, "[[", "to")),
-    query = unlist_character(lapply(edges, "[[", "query")),
-    files = I(unname(unlist(lapply(edges, "[[", "files"), FALSE))))
+  if (length(edges) == 0) {
+    data_frame(from = character(),
+               to = character(),
+               query = character(),
+               files = I(list()))
+  } else {
+    data_frame(
+      from = unlist(lapply(edges, "[[", "from"), FALSE, FALSE),
+      to = unlist(lapply(edges, "[[", "to"), FALSE, FALSE),
+      query = unlist(lapply(edges, "[[", "query"), FALSE, FALSE),
+      files = I(unname(unlist(lapply(edges, "[[", "files"), FALSE))))
+  }
 }

--- a/R/util.R
+++ b/R/util.R
@@ -580,3 +580,8 @@ pretty_bytes <- function(n) {
   }
   paste(prettyNum(round(n, 1), big.mark = ","), unit)
 }
+
+
+unlist_character <- function(x) {
+  if (length(x) == 0) character() else unlist(x, FALSE, FALSE)
+}

--- a/R/util.R
+++ b/R/util.R
@@ -580,8 +580,3 @@ pretty_bytes <- function(n) {
   }
   paste(prettyNum(round(n, 1), big.mark = ","), unit)
 }
-
-
-unlist_character <- function(x) {
-  if (length(x) == 0) character() else unlist(x, FALSE, FALSE)
-}

--- a/tests/testthat/test-graph.R
+++ b/tests/testthat/test-graph.R
@@ -1,0 +1,35 @@
+test_that("can retrieve simple graph information", {
+  root <- create_temporary_root()
+  ids <- create_random_packet_chain(root, 3)
+
+  expect_error(
+    orderly_graph_packets(from = ids[["a"]], to = ids[["c"]], root = root),
+    "Exactly one of 'from' and 'to' must be given")
+  expect_error(
+    orderly_graph_packets(root = root),
+    "Exactly one of 'from' and 'to' must be given")
+
+  g1 <- orderly_graph_packets(to = ids[["c"]], root = root)
+  expect_equal(g1$packets, unname(ids))
+  expect_equal(nrow(g1$edges), 2)
+  expect_equal(g1$edges$from, unname(ids[2:1]))
+  expect_equal(g1$edges$to, unname(ids[3:2]))
+  expect_equal(names(g1$edges), c("from", "to", "query", "files"))
+
+  g2 <- orderly_graph_packets(to = ids[["a"]], root = root)
+  expect_equal(g2$packets, ids[[1]])
+  expect_equal(nrow(g2$edges), 0)
+  expect_equal(g2$edges, g1$edges[integer(), ])
+
+  g3 <- orderly_graph_packets(from = ids[["c"]], root = root)
+  expect_equal(g3$packets, ids[[3]])
+  expect_equal(nrow(g3$edges), 0)
+  expect_equal(g3$edges, g2$edges)
+  
+  g4 <- orderly_graph_packets(from = ids[["a"]], root = root)
+  expect_equal(g4$packets, unname(ids))
+  expect_equal(nrow(g4$edges), 2)
+  expect_equal(g4$edges$from, unname(ids[1:2]))
+  expect_equal(g4$edges$to, unname(ids[2:3]))
+  expect_equal(names(g4$edges), c("from", "to", "query", "files"))
+})

--- a/tests/testthat/test-graph.R
+++ b/tests/testthat/test-graph.R
@@ -25,7 +25,7 @@ test_that("can retrieve simple graph information", {
   expect_equal(g3$packets, ids[[3]])
   expect_equal(nrow(g3$edges), 0)
   expect_equal(g3$edges, g2$edges)
-  
+
   g4 <- orderly_graph_packets(from = ids[["a"]], root = root)
   expect_equal(g4$packets, unname(ids))
   expect_equal(nrow(g4$edges), 2)


### PR DESCRIPTION
This PR just puts some code in place to pull the bits that we might want to be able to create a DAG over orderly packets (**not** yet the source reports, which is quite a different problem, especially if people lean into the orderly2 features).

This is not yet exported to the users because we need a nice way to display it, but will hopefully be something we connect up to a nice js package