### PR TITLE
Allow use of NULL for name in dependency

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: orderly2
 Title: Orderly Next Generation
-Version: 1.99.6
+Version: 1.99.7
 Authors@R: c(person("Rich", "FitzJohn", role = c("aut", "cre"),
                     email = "rich.fitzjohn@gmail.com"),
              person("Robert", "Ashton", role = "aut"),

--- a/R/metadata.R
+++ b/R/metadata.R
@@ -247,7 +247,9 @@ static_orderly_artefact <- function(args) {
 ##' @return Undefined
 ##' @export
 orderly_dependency <- function(name, query, files) {
-  assert_scalar_character(name, call = environment())
+  if (!is.null(name)) {
+    assert_scalar_character(name, call = environment())
+  }
 
   ctx <- orderly_context(rlang::caller_env())
   subquery <- NULL
@@ -276,6 +278,9 @@ static_orderly_dependency <- function(args) {
   query <- args$query
   files <- args$files
 
+  static_name <- static_string(name)
+  has_name <- !is.null(static_name) || is.null(name)
+
   name <- static_string(name)
   files <- static_character_vector(files, TRUE)
 
@@ -288,10 +293,10 @@ static_orderly_dependency <- function(args) {
     query <- NULL
   }
 
-  if (is.null(name) || is.null(files) || is.null(query)) {
+  if (!has_name || is.null(files) || is.null(query)) {
     return(NULL)
   }
-  list(name = name, query = query, files = files)
+  list(name = static_name, query = query, files = files)
 }
 
 

--- a/tests/testthat/test-read.R
+++ b/tests/testthat/test-read.R
@@ -56,6 +56,9 @@ test_that("read dependency", {
   args <- list(name = "a", query = "latest", files = c(x = "y"))
   expect_equal(static_orderly_dependency(args), args)
 
+  args <- list(name = NULL, query = "latest", files = c(x = "y"))
+  expect_equal(static_orderly_dependency(args), args)
+
   expect_null(
     static_orderly_dependency(list(name = quote(a),
                                    query = "latest",


### PR DESCRIPTION
This allows use of an id as a query without a name, it would also allows for queries that might compute a name, I guess. Mostly for completeness, but I made the ticket so must have run into a situation where this might have been preferable?