### PR TITLE
Simplify orderly initialisation

### DIFF
--- a/R/example.R
+++ b/R/example.R
@@ -31,6 +31,6 @@ orderly_example <- function(name, ..., dest = NULL) {
   }
   src <- orderly2_file("example")
   fs::dir_copy(src, dest)
-  orderly2::orderly_init(..., path = dest)
+  orderly2::orderly_init(..., root = dest)
   invisible(dest)
 }

--- a/man/orderly_init.Rd
+++ b/man/orderly_init.Rd
@@ -5,15 +5,18 @@
 \title{Initialise an orderly repository}
 \usage{
 orderly_init(
-  path,
+  root = ".",
   path_archive = "archive",
   use_file_store = FALSE,
   require_complete_tree = FALSE
 )
 }
 \arguments{
-\item{path}{The path to initialise the repository at.  If the
-repository is already initialised, this operation does nothing.}
+\item{root}{The path to initialise the repository root at.  If the
+repository is already initialised, this operation checks that
+the options passed in are the same as those set in the
+repository (erroring if not), but otherwise does nothing.  The
+default path is the current working directory.}
 
 \item{path_archive}{Path to the archive directory, used to store
 human-readable copies of packets.  If \code{NULL}, no such copy is

--- a/tests/testthat/test-init.R
+++ b/tests/testthat/test-init.R
@@ -4,7 +4,7 @@ test_that("Initialisation requires empty directory", {
   on.exit(unlink(tmp, recursive = TRUE))
   file.create(file.path(tmp, "file"))
   expect_error(orderly_init_quietly(tmp),
-               "'path' exists but is not empty, or an outpack archive")
+               "'root' exists but is not empty, or an outpack archive")
 })
 
 
@@ -99,7 +99,7 @@ test_that("Initialisation can't be done into a file", {
   tmp <- withr::local_tempfile()
   file.create(tmp)
   expect_error(orderly_init_quietly(tmp),
-               "'path' exists but is not a directory")
+               "'root' exists but is not a directory")
 })
 
 
@@ -177,4 +177,12 @@ test_that("inform about weirdly nested roots: orderly in outpack", {
       i = sprintf("outpack was found at '%s/a/b'", root),
       x = "outpack is nested within orderly at 'a/b'",
       i = "How did you even do this? Please let us know!"))
+})
+
+
+test_that("create root in wd by default", {
+  path <- withr::local_tempdir()
+  root <- withr::with_dir(path, suppressMessages(orderly_init()))
+  expect_true(file.exists(file.path(path, ".outpack")))
+  expect_true(file.exists(file.path(path, "orderly_config.yml")))
 })


### PR DESCRIPTION
As discussed in mrc-4725, make `orderly_init` more consistent with other functions:

* use `root` as the argument, not `path`. This had been a deliberate decision but clearly not a useful one
* allow initialisation of the current directory by default (i.e., use a default arg of `"."`). This is something frowned upon by CRAN, but I can see the argument in favour

Possibly we should prevent nested repository creation (i.e., check on creation that no parent directory has .outpack) but git does not do that