### PR TITLE
Allow 'here' in dependencies to have trailing slash

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: orderly2
 Title: Orderly Next Generation
-Version: 1.99.12
+Version: 1.99.13
 Authors@R: c(person("Rich", "FitzJohn", role = c("aut", "cre"),
                     email = "rich.fitzjohn@gmail.com"),
              person("Robert", "Ashton", role = "aut"),

--- a/R/outpack_helpers.R
+++ b/R/outpack_helpers.R
@@ -159,8 +159,9 @@ plan_copy_files <- function(root, id, there, here, call = NULL) {
     expanded <- lapply(which(is_dir), function(i) {
       p <- there[[i]]
       j <- string_starts_with(p, files)
-      set_names(files[j],
-                file.path(here[[i]], string_drop_prefix(p, files[j])))
+      nms <- file.path(sub("/+$", "", here[[i]]),
+                       string_drop_prefix(p, files[j]))
+      set_names(files[j], nms)
     })
 
     there <- replace_ragged(there, is_dir, lapply(expanded, unname))

--- a/tests/testthat/test-run.R
+++ b/tests/testthat/test-run.R
@@ -828,6 +828,29 @@ test_that("can depend on a directory artefact", {
 })
 
 
+test_that("can depend on a directory artefact with trailing slash", {
+  path <- test_prepare_orderly_example("directories")
+  envir1 <- new.env()
+  id1 <- orderly_run_quietly("directories", root = path, envir = envir1)
+
+  path_src <- file.path(path, "src", "use")
+  fs::dir_create(path_src)
+  writeLines(c(
+    'orderly2::orderly_dependency("directories", "latest()", "output/")',
+    'orderly2::orderly_artefact("data", "d.rds")',
+    'd <- c(readRDS("output/a.rds", "output/b.rds"))',
+    'saveRDS(d, "d.rds")'),
+    file.path(path_src, "orderly.R"))
+  envir2 <- new.env()
+  id2 <- orderly_run_quietly("use", root = path, envir = envir2)
+  meta <- orderly_metadata(id2, root = path)
+  expect_equal(meta$depends$packet, id1)
+  expect_equal(meta$depends$files[[1]],
+               data_frame(here = c("output/a.rds", "output/b.rds"),
+                          there = c("output/a.rds", "output/b.rds")))
+})
+
+
 test_that("can compute dependencies", {
   path <- test_prepare_orderly_example("parameters")
   envir1 <- new.env()


### PR DESCRIPTION
Reported by Pete; this allows pulling orderly dependencies that are directories where we don't rename them (or equivalently where the 'here' section has a trailing slash)