### PR TITLE
Remove root src

### DIFF
--- a/R/run.R
+++ b/R/run.R
@@ -104,6 +104,12 @@
 ##'   depending on the configuration. (Later this will make more sense
 ##'   once we support a "bare" outpack layout.)
 ##'
+##' @section Manually setting report source directory:
+##'
+##' To manually set the report source directory, you will need to set
+##'   the path of the directory as the `ORDERLY_REPORT_SRC` environment
+##'   variable.
+##'
 ##' @title Run a report
 ##'
 ##' @param name Name of the report to run. Any leading `./` `src/` or
@@ -136,12 +142,6 @@
 ##'   then orderly looks in the working directory and up through its
 ##'   parents until it finds an `.outpack` directory
 ##'
-##' @param root_src Separately, the root of the orderly source tree,
-##'   if separate from the outpack root (given as `root`). This is
-##'   intended for running reports in situations where the source tree
-##'   is kept in a different place to the outpack root; see Details
-##'   for more information.
-##'
 ##' @return The id of the created report (a string)
 ##'
 ##' @export
@@ -158,16 +158,16 @@
 ##' # and we can query the metadata:
 ##' orderly2::orderly_metadata_extract(name = "data", root = path)
 orderly_run <- function(name, parameters = NULL, envir = NULL, echo = TRUE,
-                        search_options = NULL, root = NULL, locate = TRUE,
-                        root_src = NULL) {
-  if (is.null(root_src)) {
-    root <- root_open(root, locate, require_orderly = TRUE,
-                      call = environment())
+                        search_options = NULL, root = NULL, locate = TRUE) {
+  env_src <- Sys.getenv("ORDERLY_REPORT_SRC")
+  is_env_src_empty <- !nzchar(env_src)
+  root <- root_open(root, locate, require_orderly = is_env_src_empty,
+                    call = environment())
+
+  if (is_env_src_empty) {
     root_src <- root$path
   } else {
-    root <- root_open(root, locate, require_orderly = FALSE,
-                      call = environment())
-    root_src <- orderly_src_root(root_src, locate, call = environment())
+    root_src <- orderly_src_root(env_src, locate, call = environment())
   }
 
   name <- validate_orderly_directory(name, root_src, environment())

--- a/R/run.R
+++ b/R/run.R
@@ -159,15 +159,14 @@
 ##' orderly2::orderly_metadata_extract(name = "data", root = path)
 orderly_run <- function(name, parameters = NULL, envir = NULL, echo = TRUE,
                         search_options = NULL, root = NULL, locate = TRUE) {
-  env_src <- Sys.getenv("ORDERLY_REPORT_SRC")
-  is_env_src_empty <- !nzchar(env_src)
-  root <- root_open(root, locate, require_orderly = is_env_src_empty,
+  env_root_src <- Sys.getenv("ORDERLY_SRC_ROOT", NA_character_)
+  root <- root_open(root, locate, require_orderly = is.na(env_root_src),
                     call = environment())
 
-  if (is_env_src_empty) {
+  if (is.na(env_root_src)) {
     root_src <- root$path
   } else {
-    root_src <- orderly_src_root(env_src, locate, call = environment())
+    root_src <- orderly_src_root(env_root_src, locate, call = environment())
   }
 
   name <- validate_orderly_directory(name, root_src, environment())

--- a/man/orderly_run.Rd
+++ b/man/orderly_run.Rd
@@ -11,8 +11,7 @@ orderly_run(
   echo = TRUE,
   search_options = NULL,
   root = NULL,
-  locate = TRUE,
-  root_src = NULL
+  locate = TRUE
 )
 }
 \arguments{
@@ -45,12 +44,6 @@ directory is configured for orderly, and not just outpack (see
 searched for.  If \code{TRUE} and \code{config} is not given,
 then orderly looks in the working directory and up through its
 parents until it finds an \code{.outpack} directory}
-
-\item{root_src}{Separately, the root of the orderly source tree,
-if separate from the outpack root (given as \code{root}). This is
-intended for running reports in situations where the source tree
-is kept in a different place to the outpack root; see Details
-for more information.}
 }
 \value{
 The id of the created report (a string)
@@ -168,6 +161,14 @@ contains the directory \verb{.outpack/} with all the metadata - it
 may also have an unpacked archive, and a \verb{.git/} directory
 depending on the configuration. (Later this will make more sense
 once we support a "bare" outpack layout.)
+}
+
+\section{Manually setting report source directory}{
+
+
+To manually set the report source directory, you will need to set
+the path of the directory as the \code{ORDERLY_REPORT_SRC} environment
+variable.
 }
 
 \examples{

--- a/tests/testthat/test-run-separate.R
+++ b/tests/testthat/test-run-separate.R
@@ -1,7 +1,9 @@
 test_that("can run simple case in separate directory", {
   info <- test_prepare_orderly_example_separate("explicit")
-  id <- orderly_run_quietly("explicit", envir = new.env(),
-                            root = info$outpack, root_src = info$src)
+  id <- withr::with_envvar(
+    c(ORDERLY_REPORT_SRC = info$src),
+    orderly_run_quietly("explicit", envir = new.env(), root = info$outpack)
+  )
   expect_type(id, "character")
   expect_true(file.exists(file.path(info$src, "draft")))
   expect_false(file.exists(file.path(info$src, "archive")))
@@ -16,9 +18,10 @@ test_that("can run shared resources case in separate directory", {
   ## resources are relative to the *source* tree and not the outpack
   ## root.
   info <- test_prepare_orderly_example_separate("shared")
-  envir <- new.env()
-  id <- orderly_run_quietly("shared", envir = envir,
-                            root = info$outpack, root_src = info$src)
+  id <- withr::with_envvar(
+    c(ORDERLY_REPORT_SRC = info$src),
+    orderly_run_quietly("shared", envir = new.env(), root = info$outpack)
+  )
   expect_setequal(
     dir(file.path(info$outpack, "archive", "shared", id)),
     c("shared_data.csv", "mygraph.png", "shared.R"))
@@ -28,13 +31,14 @@ test_that("can run shared resources case in separate directory", {
 test_that("can use dependencies in separate directory", {
   ## Ensures that we hit the outpack root for pulling deps in
   info <- test_prepare_orderly_example_separate(c("data", "depends"))
-  envir1 <- new.env()
-  id1 <- orderly_run_quietly("data", envir = envir1,
-                             root = info$outpack, root_src = info$src)
-  envir2 <- new.env()
-  id2 <- orderly_run_quietly("depends", envir = envir2,
-                             root = info$outpack, root_src = info$src)
-
+  id1 <- withr::with_envvar(
+    c(ORDERLY_REPORT_SRC = info$src),
+    orderly_run_quietly("data", envir = new.env(), root = info$outpack)
+  )
+  id2 <- withr::with_envvar(
+    c(ORDERLY_REPORT_SRC = info$src),
+    orderly_run_quietly("depends", envir = new.env(), root = info$outpack)
+  )
   path1 <- file.path(info$outpack, "archive", "data", id1)
   path2 <- file.path(info$outpack, "archive", "depends", id2)
 
@@ -48,8 +52,10 @@ test_that("can use dependencies in separate directory", {
 test_that("can get git information in separate directory", {
   info <- test_prepare_orderly_example_separate("explicit")
   info$git <- helper_add_git(info$src)
-  id <- orderly_run_quietly("explicit", envir = new.env(),
-                            root = info$outpack, root_src = info$src)
+  id <- withr::with_envvar(
+    c(ORDERLY_REPORT_SRC = info$src),
+    orderly_run_quietly("explicit", envir = new.env(), root = info$outpack)
+  )
   meta <- orderly_metadata(id, root = info$outpack)
   expect_mapequal(meta$git, info$git[c("sha", "branch", "url")])
 })
@@ -59,13 +65,13 @@ test_that("can't run interactively in separate directory", {
   ## Picking on depends here because it really requires the outpack
   ## root
   info <- test_prepare_orderly_example_separate(c("data", "depends"))
-  envir1 <- new.env()
-  id1 <- orderly_run_quietly("data", envir = envir1,
-                             root = info$outpack, root_src = info$src)
-  envir2 <- new.env()
+  id1 <- withr::with_envvar(
+    c(ORDERLY_REPORT_SRC = info$src),
+    orderly_run_quietly("data", envir = new.env(), root = info$outpack)
+  )
   path_src <- file.path(info$src, "src", "depends")
   expect_error(
     withr::with_dir(path_src,
-                    sys.source("depends.R", envir2)),
+                    sys.source("depends.R", new.env())),
     "orderly directory '.+' not initialised")
 })

--- a/tests/testthat/test-run-separate.R
+++ b/tests/testthat/test-run-separate.R
@@ -1,7 +1,7 @@
 test_that("can run simple case in separate directory", {
   info <- test_prepare_orderly_example_separate("explicit")
   id <- withr::with_envvar(
-    c(ORDERLY_REPORT_SRC = info$src),
+    c(ORDERLY_SRC_ROOT = info$src),
     orderly_run_quietly("explicit", envir = new.env(), root = info$outpack)
   )
   expect_type(id, "character")
@@ -19,7 +19,7 @@ test_that("can run shared resources case in separate directory", {
   ## root.
   info <- test_prepare_orderly_example_separate("shared")
   id <- withr::with_envvar(
-    c(ORDERLY_REPORT_SRC = info$src),
+    c(ORDERLY_SRC_ROOT = info$src),
     orderly_run_quietly("shared", envir = new.env(), root = info$outpack)
   )
   expect_setequal(
@@ -32,11 +32,11 @@ test_that("can use dependencies in separate directory", {
   ## Ensures that we hit the outpack root for pulling deps in
   info <- test_prepare_orderly_example_separate(c("data", "depends"))
   id1 <- withr::with_envvar(
-    c(ORDERLY_REPORT_SRC = info$src),
+    c(ORDERLY_SRC_ROOT = info$src),
     orderly_run_quietly("data", envir = new.env(), root = info$outpack)
   )
   id2 <- withr::with_envvar(
-    c(ORDERLY_REPORT_SRC = info$src),
+    c(ORDERLY_SRC_ROOT = info$src),
     orderly_run_quietly("depends", envir = new.env(), root = info$outpack)
   )
   path1 <- file.path(info$outpack, "archive", "data", id1)
@@ -53,7 +53,7 @@ test_that("can get git information in separate directory", {
   info <- test_prepare_orderly_example_separate("explicit")
   info$git <- helper_add_git(info$src)
   id <- withr::with_envvar(
-    c(ORDERLY_REPORT_SRC = info$src),
+    c(ORDERLY_SRC_ROOT = info$src),
     orderly_run_quietly("explicit", envir = new.env(), root = info$outpack)
   )
   meta <- orderly_metadata(id, root = info$outpack)
@@ -66,7 +66,7 @@ test_that("can't run interactively in separate directory", {
   ## root
   info <- test_prepare_orderly_example_separate(c("data", "depends"))
   id1 <- withr::with_envvar(
-    c(ORDERLY_REPORT_SRC = info$src),
+    c(ORDERLY_SRC_ROOT = info$src),
     orderly_run_quietly("data", envir = new.env(), root = info$outpack)
   )
   path_src <- file.path(info$src, "src", "depends")


### PR DESCRIPTION
This allows us to specify `root_src` via an environment variable `ORDERLY_SRC_ROOT` instead of users being able to pass this in as an argument. This is good because we don't really need the users to be passing in their `root_src`.