### PR TITLE
Add support for authenticating against packit

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -11,7 +11,7 @@ Description: Reimplementation of orderly based on outpack.
 License: MIT + file LICENSE
 Encoding: UTF-8
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.2.3
+RoxygenNote: 7.3.1
 URL: https://github.com/mrc-ide/orderly2
 BugReports: https://github.com/mrc-ide/orderly2/issues
 Imports:

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: orderly2
 Title: Orderly Next Generation
-Version: 1.99.13
+Version: 1.99.14
 Authors@R: c(person("Rich", "FitzJohn", role = c("aut", "cre"),
                     email = "rich.fitzjohn@gmail.com"),
              person("Robert", "Ashton", role = "aut"),

--- a/R/location_http.R
+++ b/R/location_http.R
@@ -92,10 +92,13 @@ orderly_location_packit <- function(url, token) {
     token <- Sys.getenv(token_variable, NA_character_)
     if (is.na(token)) {
       cli::cli_abort(
-        "Environment value '{token_variable}' was not set")
+        "Environment variable '{token_variable}' was not set")
     }
   }
 
+  if (!grepl("/$", url)) {
+    url <- paste0(url, "/")
+  }
   url_login <- paste0(url, "packit/api/auth/login/api")
   url_outpack <- paste0(url, "packit/api/outpack")
 

--- a/R/location_http.R
+++ b/R/location_http.R
@@ -6,8 +6,8 @@ orderly_location_http <- R6::R6Class(
   ),
 
   public = list(
-    initialize = function(url) {
-      private$client <- outpack_http_client$new(url)
+    initialize = function(url, auth = NULL) {
+      private$client <- outpack_http_client$new(url, auth)
     },
 
     list = function() {
@@ -82,3 +82,23 @@ orderly_location_http <- R6::R6Class(
       invisible(NULL)
     }
   ))
+
+
+orderly_location_packit <- function(url, token) {
+  assert_scalar_character(url)
+  assert_scalar_character(token)
+  if (grepl("^\\$", token)) {
+    token_variable <- sub("^\\$", "", token)
+    token <- Sys.getenv(token_variable, NA_character_)
+    if (is.na(token)) {
+      cli::cli_abort(
+        "Environment value '{token_variable}' was not set")
+    }
+  }
+
+  url_login <- paste0(url, "packit/api/auth/login/api")
+  url_outpack <- paste0(url, "packit/api/outpack")
+
+  auth <- list(url = url_login, data = list(token = scalar(token)))
+  orderly_location_http$new(url_outpack, auth)
+}

--- a/R/outpack_http_client.R
+++ b/R/outpack_http_client.R
@@ -1,33 +1,50 @@
-## NOTE: none of the auth bits here are done yet - we have a system in
-## the orderlyweb client that lets us do this in a fairly pluggable
-## way, supporting username/password and token based auth (with the
-## former getting a token via username/password)
 outpack_http_client <- R6::R6Class(
   "outpack_http_client",
 
+  private = list(
+    auth = NULL
+  ),
+
   public = list(
     url = NULL,
+    token = NULL,
 
-    initialize = function(url) {
+    initialize = function(url, auth) {
       self$url <- url
+      if (is.null(auth)) {
+        private$auth <- list(enabled = FALSE)
+      } else {
+        private$auth <- list(enabled = TRUE, url = auth$url, data = auth$data)
+      }
+    },
+
+    authorise = function() {
+      needs_auth <- private$auth$enabled && is.null(private$auth$header)
+      if (needs_auth) {
+        private$auth$header <- http_client_login(self$url, private$auth)
+      }
     },
 
     get = function(path, ...) {
-      http_client_request(httr::GET, self$url, path, ...)
+      self$authorise()
+      http_client_request(httr::GET, paste0(self$url, path), ...,
+                          private$auth$header)
     },
 
     post = function(path, body, ...) {
-      http_client_request(httr::POST, self$url, path, body = body, ...)
+      self$authorise()
+      http_client_request(httr::POST, paste0(self$url, path), body = body, ...,
+                          private$auth$header)
     }
   ))
 
 
-http_client_request <- function(verb, server, path, ..., parse_json = TRUE,
+http_client_request <- function(verb, url, ..., parse_json = TRUE,
                                 download = NULL) {
   if (is.null(download)) {
-    response <- verb(paste0(server, path), ...)
+    response <- verb(url, ...)
   } else {
-    response <- verb(paste0(server, path), ...,
+    response <- verb(url, ...,
                      http_client_download_options(download))
   }
 
@@ -45,16 +62,19 @@ http_client_request <- function(verb, server, path, ..., parse_json = TRUE,
 }
 
 
-## This could probably be simplified considerably, it was designed to
-## cope with something like docker or vault where we were less in
-## control of the errors, and we can always put back in some better
-## support later.
 http_client_handle_error <- function(response) {
+  ## TODO: we can cope with timeouts here with some care; if we know
+  ## that an expired timeout produces a certain error code we watch
+  ## for that and then reauthenticate; that requires that a callback
+  ## is passed through here too.
   code <- httr::status_code(response)
   if (code >= 400) {
     txt <- httr::content(response, "text", encoding = "UTF-8")
     res <- from_json(txt)
-    stop(http_client_error(res$errors[[1]]$detail, code, res$errors))
+    ## I am seeing Packit returning an element 'error' not a list of
+    ## errors
+    errors <- if ("error" %in% names(res)) list(res$error) else res$errors
+    stop(http_client_error(errors[[1]]$detail, code, errors))
   }
   response
 }
@@ -70,4 +90,29 @@ http_client_error <- function(msg, code, errors) {
 http_client_download_options <- function(dest) {
   c(httr::write_disk(dest),
     httr::accept("application/octet-stream"))
+}
+
+
+## Logging in with packit is quite slow and we'll want to cache this;
+## but we won't be holding a persistant handle to the root.  So for
+## now at least we'll keep a pool of generated bearer token headers,
+## stored against the hash of the auth details (so the url and the
+## token used to log in with).  We only store this on successful
+## login.
+##
+## This does mean there's no way to flush the cache and force a login,
+## but that should hopefully not be that big a problem.  We'll
+## probably want to refresh the tokens from the request anyway.
+auth_cache <- new.env(parent = emptyenv())
+http_client_login <- function(name, auth) {
+  key <- rlang::hash(auth)
+  if (is.null(auth_cache[[key]])) {
+    cli::cli_alert_info("Logging in to {name}")
+    res <- http_client_request(httr::POST, auth$url,
+                               body = auth$data, encode = "json")
+    cli::cli_alert_success("Logged in successfully")
+    auth_cache[[key]] <- httr::add_headers(
+      "Authorization" = paste("Bearer", res$token))
+  }
+  auth_cache[[key]]
 }

--- a/R/outpack_http_client.R
+++ b/R/outpack_http_client.R
@@ -1,40 +1,36 @@
 outpack_http_client <- R6::R6Class(
   "outpack_http_client",
 
-  private = list(
-    auth = NULL
-  ),
-
   public = list(
     url = NULL,
-    token = NULL,
+    auth = NULL,
 
     initialize = function(url, auth) {
-      self$url <- url
+      self$url <- sub("/$", "", url)
       if (is.null(auth)) {
-        private$auth <- list(enabled = FALSE)
+        self$auth <- list(enabled = FALSE)
       } else {
-        private$auth <- list(enabled = TRUE, url = auth$url, data = auth$data)
+        self$auth <- list(enabled = TRUE, url = auth$url, data = auth$data)
       }
     },
 
     authorise = function() {
-      needs_auth <- private$auth$enabled && is.null(private$auth$header)
+      needs_auth <- self$auth$enabled && is.null(self$auth$header)
       if (needs_auth) {
-        private$auth$header <- http_client_login(self$url, private$auth)
+        self$auth$header <- http_client_login(self$url, self$auth)
       }
     },
 
     get = function(path, ...) {
       self$authorise()
       http_client_request(httr::GET, paste0(self$url, path), ...,
-                          private$auth$header)
+                          self$auth$header)
     },
 
     post = function(path, body, ...) {
       self$authorise()
       http_client_request(httr::POST, paste0(self$url, path), body = body, ...,
-                          private$auth$header)
+                          self$auth$header)
     }
   ))
 

--- a/R/outpack_misc.R
+++ b/R/outpack_misc.R
@@ -2,7 +2,7 @@
 local <- "local"
 orphan <- "orphan"
 location_reserved_name <- c(local, orphan)
-location_types <- c(local, orphan, "path", "http", "custom")
+location_types <- c(local, orphan, "path", "http", "packit", "custom")
 re_id <- "^([0-9]{8}-[0-9]{6}-[[:xdigit:]]{8})$"
 
 

--- a/man/orderly_location_add.Rd
+++ b/man/orderly_location_add.Rd
@@ -44,11 +44,12 @@ from it, you need to call
 \details{
 We currently support two types of locations - \code{path}, which points
 to an outpack archive accessible by path (e.g., on the same
-computer or on a mounted network share) and \code{http}, which requires
+computer or on a mounted network share), \code{http}, which requires
 that an outpack server is running at some url and uses an HTTP API
-to communicate. More types may be added later, and more
-configuration options to these location types will definitely be
-needed in future.
+to communicate, and \code{packit}, which uses Packit as a web
+server.  More types may be added later, and more configuration
+options to these location types will definitely be needed in
+future.
 
 Configuration options for different location types:
 
@@ -68,6 +69,18 @@ authentication.
 \itemize{
 \item \code{url}: The location of the server, including protocol, for
 example \verb{http://example.com:8080}
+}
+
+\strong{Packit locations}:
+
+Packit locations work over HTTPS, and include everything in an
+outpack location but also provide authentication and later will
+have more capabilities we think.
+\itemize{
+\item \code{url}: The location of the server
+\item \code{token}: The value for your your login token (currently this is
+a GitHub token with \code{read:org} scope).  Later we'll expand this
+as other authentication modes are supported.
 }
 
 \strong{Custom locations}:

--- a/tests/testthat/helper-outpack-http.R
+++ b/tests/testthat/helper-outpack-http.R
@@ -29,3 +29,8 @@ json_string <- function(s) {
   class(s) <- "json"
   s
 }
+
+
+clear_auth_cache <- function() {
+  rm(list = ls(auth_cache), envir = auth_cache)
+}

--- a/tests/testthat/test-location.R
+++ b/tests/testthat/test-location.R
@@ -765,9 +765,18 @@ test_that("validate arguments to packit locations", {
 test_that("can add a packit location", {
   root <- create_temporary_root()
   orderly_location_add("other", "packit",
-                       list(url = "example.com", token = "abc123"),
+                       list(url = "https://example.com", token = "abc123"),
                        root = root)
   expect_equal(orderly_location_list(root = root), c("local", "other"))
+  dr <- location_driver("other", root)
+  expect_s3_class(dr, "orderly_location_http") # not actually packit
+  cl <- dr$.__enclos_env__$private$client
+  expect_equal(cl$url, "https://example.com/packit/api/outpack")
+  expect_equal(
+    cl$auth,
+    list(enabled = TRUE,
+         url = "https://example.com/packit/api/auth/login/api",
+         data = list(token = scalar("abc123"))))
 })
 
 

--- a/tests/testthat/test-outpack-http-client.R
+++ b/tests/testthat/test-outpack-http-client.R
@@ -141,7 +141,7 @@ test_that("can send authentication request", {
 
   auth <- list(
     url = "https://example.com/login",
-    data = list(token = ids::random_id()))
+    data = list(token = "98e02a382db6a3a18e9d2e02c698478b"))
   mock_post <- mockery::mock(
     mock_response(
       to_json(list(token = jsonlite::unbox("mytoken"))),

--- a/tests/testthat/test-zzz-location-http.R
+++ b/tests/testthat/test-zzz-location-http.R
@@ -121,7 +121,7 @@ describe("http location integration tests", {
     )
 
     ## Trigger the error directly:
-    cl <- outpack_http_client$new(url)
+    cl <- outpack_http_client$new(url, NULL)
     err <- expect_error(cl$post(sprintf("/packet/%s", hash), meta,
                                 httr::content_type("text/plain")),
                         "Expected hash '.+' but found '.+'")


### PR DESCRIPTION
Implement support for using packit as a location for orderly2.

There were two broad ways I thought we might do this; one is that we say that packit locations are merely http ones and we add support for optional auth and the users have to give the url with `/packit/api/outpack`, but this feels like the users will have to do remember to add a url that looks quite different to the one they feel it should be.

So I've gone with a new location type "packit".  This turns out to be useful because the login url is actually above the location where we refer to outpack

```
/packit/api/auth/login/api         the login url
/packit/api/outpack/metadata/list  example api url
```

This approach leaves the configuration fairly tidy I think, and requires no schema updates.

Otherwise not that much to see in the implementation:

* I've added in some basic slash sanitisation for both http and packit remotes (it should not matter if there is or is not a trailing slash)
* the token can come from an envvar; we might support using the keychain later but that's more work
* login is very slow so I've made a global cache of logins against a hash of auth data
* packit produces errors in slightly different format to outpack; we should harmonise these at some point
* in orderlyweb (for orderly1) we refreshed the token on timeout; that can be handled fairly easily (see comment in `http_client_handle_error`)
* the testing is all gross and mocky

I can run this up locally with:

```r
tmp <- tempfile()
orderly_init(tmp)
orderly_location_add(
  "malaria",
  "packit",
  list(url = "https://malaria-orderly.dide.ic.ac.uk/",
       token = "$VAULT_AUTH_GITHUB_TOKEN"),
  root = tmp)
orderly_location_list(root = tmp)
orderly_location_pull_metadata(root = tmp)
```

Subsequent calls to `orderly_location_pull_metadata` won't log back in, and will reuse the jwt