### PR TITLE
Make tests more isolated.

### DIFF
--- a/tests/testthat/test-cleanup.R
+++ b/tests/testthat/test-cleanup.R
@@ -217,7 +217,7 @@ test_that("Don't call cleanup on an active packet", {
   append_lines(file.path(path_src, "data.R"),
                "orderly2::orderly_cleanup_status()")
   expect_error(
-    orderly_run_quietly("data", root = path),
+    orderly_run_quietly("data", root = path, envir = new.env()),
     "Don't call 'orderly2::orderly_cleanup_status()' from a running packet",
     fixed = TRUE)
 })

--- a/tests/testthat/test-init.R
+++ b/tests/testthat/test-init.R
@@ -47,7 +47,8 @@ test_that("can initialise a repo with orderly but no .outpack directory", {
   base <- basename(path)
   unlink(file.path(path, ".outpack"), recursive = TRUE)
   err <- expect_error(
-    withr::with_dir(parent, orderly_run_quietly("data", root = base)),
+    withr::with_dir(parent,
+      orderly_run_quietly("data", root = base, envir = new.env())),
     sprintf("orderly directory '%s' not initialise", base))
   expect_equal(
     err$body,
@@ -60,7 +61,8 @@ test_that("can initialise a repo with orderly but no .outpack directory", {
   root <- root_open(path, FALSE, TRUE)
   expect_true(is_directory(file.path(path, ".outpack")))
 
-  id <- withr::with_dir(parent, orderly_run_quietly("data", root = base))
+  id <- withr::with_dir(parent,
+    orderly_run_quietly("data", root = base, envir = new.env()))
   expect_type(id, "character")
 })
 

--- a/tests/testthat/test-parameters.R
+++ b/tests/testthat/test-parameters.R
@@ -151,7 +151,8 @@ test_that("parameters must be atomic scalars", {
     c("x" = "Values must be character, numeric or boolean, but were not for:",
       "*" = "a"))
   err <- expect_error(
-    check_parameters(list(a = utils::data, b = 2 + 1i), list(a = NULL, b = NULL)),
+    check_parameters(list(a = utils::data, b = 2 + 1i),
+                     list(a = NULL, b = NULL)),
     "Invalid parameter values\\b")
   expect_equal(
     err$body,

--- a/tests/testthat/test-parameters.R
+++ b/tests/testthat/test-parameters.R
@@ -144,14 +144,14 @@ test_that("parameters must be atomic scalars", {
       "x" = "Values must be character, numeric or boolean, but were not for:",
       "*" = "a"))
   err <- expect_error(
-    check_parameters(list(a = data, b = 2), list(a = NULL, b = NULL)),
+    check_parameters(list(a = utils::data, b = 2), list(a = NULL, b = NULL)),
     "Invalid parameter value\\b")
   expect_equal(
     err$body,
     c("x" = "Values must be character, numeric or boolean, but were not for:",
       "*" = "a"))
   err <- expect_error(
-    check_parameters(list(a = data, b = 2 + 1i), list(a = NULL, b = NULL)),
+    check_parameters(list(a = utils::data, b = 2 + 1i), list(a = NULL, b = NULL)),
     "Invalid parameter values\\b")
   expect_equal(
     err$body,
@@ -177,7 +177,7 @@ test_that("defaults must be valid", {
   expect_equal(err$body, c("x" = "Values must be scalar, but were not for:",
                            "*" = "a"))
   err <- expect_error(
-    static_orderly_parameters(list(a = data)),
+    static_orderly_parameters(list(a = utils::data)),
     "Invalid parameter default")
   expect_equal(
     err$body,


### PR DESCRIPTION
Some tests were calling `orderly_run` without an `envir` parameter,
which ends up running the report in the global environment. This
pollutes that namespace and might affect subsequent tests.

One particular issue I was hitting was a test depending on the global
`data` name from `utils`, while other tests were defining a global
variable with that (unfortunately very common) name.

I've added a `envir = new.env()` parameter to all the `orderly_run`
calls I could find, and changed the test that depended on `data` to use
the fully qualified name `utils::base`.

Running the whole test suite now leaves an unmodified global
environment:

```r
ls()
# character(0)
devtools::test()
ls()
# character(0)
```
