### PR TITLE
Use lockfile when installing outpack_server in CI.

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -52,7 +52,7 @@ jobs:
       - name: setup server
         if: runner.os != 'macOS'
         run: |
-          cargo install --git https://github.com/mrc-ide/outpack_server --branch main
+          cargo install --git https://github.com/mrc-ide/outpack_server --branch main --locked
 
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:

--- a/.github/workflows/test-coverage.yaml
+++ b/.github/workflows/test-coverage.yaml
@@ -23,7 +23,7 @@ jobs:
 
       - name: setup server
         run: |
-          cargo install --git https://github.com/mrc-ide/outpack_server --branch main
+          cargo install --git https://github.com/mrc-ide/outpack_server --branch main --locked
 
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:


### PR DESCRIPTION
Somewhere, something in the dependency tree of outpack_server something changes and caused the build to fail, which broke the orderly2 CI.

This is the kind of thing lock files are supposed to prevent, by pinning to the same package versions used in outpack_server's own CI, which should make the build reproducible. However, quite surprisingly, `cargo install` ignores the lock file by default and pulls the latest compatible version of dependencies. Passing the `--locked` argument should prevent this from happening.

I haven't investigated the underlying build failure much yet, but seems like an issue with a missing cargo feature flag.