### PR TITLE
Don't add a trailing newline to metadata files.

### DIFF
--- a/R/location.R
+++ b/R/location.R
@@ -474,7 +474,7 @@ location_pull_metadata <- function(location_name, root, call) {
                     "Please let us know how this might have happened."),
           i = hint_remove),
         call)
-      writeLines(metadata[[i]], filename[[i]])
+      writeLines(metadata[[i]], filename[[i]], sep="")
     }
   }
 

--- a/R/location.R
+++ b/R/location.R
@@ -474,7 +474,7 @@ location_pull_metadata <- function(location_name, root, call) {
                     "Please let us know how this might have happened."),
           i = hint_remove),
         call)
-      writeLines(metadata[[i]], filename[[i]], sep="")
+      writeLines(metadata[[i]], filename[[i]], sep = "")
     }
   }
 

--- a/R/location_path.R
+++ b/R/location_path.R
@@ -92,7 +92,7 @@ location_path_import_metadata <- function(str, hash, root) {
     root$files$get(meta$files$hash, dst, TRUE)
   }
 
-  writeLines(str, file.path(root$path, ".outpack", "metadata", id))
+  writeLines(str, file.path(root$path, ".outpack", "metadata", id), sep="")
   time <- Sys.time()
   mark_packet_known(id, local, hash, time, root)
 }

--- a/R/location_path.R
+++ b/R/location_path.R
@@ -92,7 +92,7 @@ location_path_import_metadata <- function(str, hash, root) {
     root$files$get(meta$files$hash, dst, TRUE)
   }
 
-  writeLines(str, file.path(root$path, ".outpack", "metadata", id), sep="")
+  writeLines(str, file.path(root$path, ".outpack", "metadata", id), sep = "")
   time <- Sys.time()
   mark_packet_known(id, local, hash, time, root)
 }

--- a/R/outpack_insert.R
+++ b/R/outpack_insert.R
@@ -34,7 +34,7 @@ outpack_insert_packet <- function(path, json, root = NULL) {
   }
 
   path_meta <- file.path(root$path, ".outpack", "metadata", id)
-  writeLines(json, path_meta)
+  writeLines(json, path_meta, sep="")
 
   ## TODO: once we get more flexible remotes, this will get moved into
   ## its own thing.

--- a/R/outpack_insert.R
+++ b/R/outpack_insert.R
@@ -34,7 +34,7 @@ outpack_insert_packet <- function(path, json, root = NULL) {
   }
 
   path_meta <- file.path(root$path, ".outpack", "metadata", id)
-  writeLines(json, path_meta, sep="")
+  writeLines(json, path_meta, sep = "")
 
   ## TODO: once we get more flexible remotes, this will get moved into
   ## its own thing.

--- a/tests/testthat/test-location-path.R
+++ b/tests/testthat/test-location-path.R
@@ -334,10 +334,11 @@ test_that("Can read metadata files with a trailing newline", {
   path <- file.path(root$path, ".outpack", "metadata", id)
 
   # Calling writeLines adds the trailing newline and mimicks the old orderly2
-  # behaviour.
+  # behaviour. The size will be one or two bytes bigger than the actual data,
+  # depending on whether the newline is `\n` or `\r\n`.
   old_size <- file.info(path)$size
   writeLines(read_string(path), path)
-  expect_equal(file.info(path)$size, old_size + 1)
+  expect_gte(file.info(path)$size, old_size + 1)
 
   # Reading the metadata from a location at that path correctly strips the
   # newline and hashes correctly.

--- a/tests/testthat/test-outpack-packet.R
+++ b/tests/testthat/test-outpack-packet.R
@@ -823,3 +823,15 @@ test_that("can overwrite dependencies", {
     hash_file(file.path(path_src, "data.rds")),
     hash_file(file.path(root$path, "archive", "data", id, "data.rds")))
 })
+
+
+test_that("metadata files match their hash", {
+  root <- create_temporary_root()
+  id <- create_random_packet(root)
+
+  location <- root$index$location(local)
+  expected_hash <- location[location$packet == id]$hash
+
+  path <- file.path(root$path, ".outpack", "metadata", id)
+  expect_no_error(hash_validate_file(expected_hash, path))
+})

--- a/tests/testthat/test-outpack-packet.R
+++ b/tests/testthat/test-outpack-packet.R
@@ -833,5 +833,5 @@ test_that("metadata files match their hash", {
   expected_hash <- location[location$packet == id]$hash
 
   path <- file.path(root$path, ".outpack", "metadata", id)
-  expect_no_error(hash_validate_file(expected_hash, path))
+  expect_no_error(hash_validate_file(path, expected_hash))
 })

--- a/tests/testthat/test-util.R
+++ b/tests/testthat/test-util.R
@@ -328,7 +328,8 @@ test_that("read_string strips newlines", {
   writeLines(c("", "12345678"), path)
 
   # 8 characters, a leading newline and a trailing one
-  expect_equal(file.info(path)$size, 10)
+  # Each newline may be one of two bytes each, depending on the platform.
+  expect_gte(file.info(path)$size, 10)
 
   result <- expect_silent(read_string(path))
   expect_equal(result, "12345678")

--- a/tests/testthat/test-util.R
+++ b/tests/testthat/test-util.R
@@ -321,3 +321,15 @@ test_that("can gracefully cope with rds save failure", {
     "some error")
   expect_equal(dir(tmp), character())
 })
+
+
+test_that("read_string strips newlines", {
+  path <- tempfile()
+  writeLines(c("", "12345678"), path)
+
+  # 8 characters, a leading newline and a trailing one
+  expect_equal(file.info(path)$size, 10)
+
+  result <- expect_silent(read_string(path))
+  expect_equal(result, "12345678")
+})


### PR DESCRIPTION
By default, the base writeLines function adds a trailing newline to the end of the file, even when the input data did not contain any. While this is generally an acceptable behaviour, in the case of metadata files, we also hash the data and embed it in location files. Because the hashing happens over the in-memory data, it does not include the trailing newline. The hash of the on-disk file therefore ends up being different from the hash stored in the location file.

It hasn't caused any practical issues because we trim leading and trailing whitespaces when reading the files back, getting the original serialized metadata that had been hashed. Similarly, when pushing a metadata file to a remote server, the client trims whitespaces from the metadata file. The behaviour is nevertheless confusing and it would be better to have consitent contents and hashes all around.

The old behaviour of trimming whitespaces on read is preserved, as we must maintain compatibility with old files that do contain the newline.