### PR TITLE
Allow initialising a project directory

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: orderly2
 Title: Orderly Next Generation
-Version: 1.99.16
+Version: 1.99.17
 Authors@R: c(person("Rich", "FitzJohn", role = c("aut", "cre"),
                     email = "rich.fitzjohn@gmail.com"),
              person("Robert", "Ashton", role = "aut"),

--- a/R/root.R
+++ b/R/root.R
@@ -79,8 +79,8 @@ orderly_init <- function(root = ".",
     if (!file.exists(file.path(root, ".outpack")) && !force) {
       allowed <- c(".outpack",
                    ".git", ".gitignore",
-                   ".Rhistory",
-                   "*.Rproj", ".Rproj.user")
+                   ".vscode",
+                   ".Rhistory", ".RData", "*.Rproj", ".Rproj.user")
       contents <- dir(root, all.files = TRUE, no.. = TRUE)
       m <- vapply(glob2rx(allowed), grepl, logical(length(contents)), contents)
       if (!is.matrix(m)) { # exactly one file to compare

--- a/man/orderly_init.Rd
+++ b/man/orderly_init.Rd
@@ -8,7 +8,8 @@ orderly_init(
   root = ".",
   path_archive = "archive",
   use_file_store = FALSE,
-  require_complete_tree = FALSE
+  require_complete_tree = FALSE,
+  force = FALSE
 )
 }
 \arguments{
@@ -35,6 +36,9 @@ always operates in recursive mode.  This is \code{FALSE} by default,
 but set to \code{TRUE} if you want your archive to behave well as a
 location; if \code{TRUE} you will always have all the packets that
 you hold metadata about.}
+
+\item{force}{Logical, indicating if we shold initialise orderly
+even if the directory is not empty.}
 }
 \value{
 The full, normalised, path to the root,

--- a/tests/testthat/test-init.R
+++ b/tests/testthat/test-init.R
@@ -188,3 +188,28 @@ test_that("create root in wd by default", {
   expect_true(file.exists(file.path(path, ".outpack")))
   expect_true(file.exists(file.path(path, "orderly_config.yml")))
 })
+
+
+test_that("allow rstudio files to exist for init", {
+  tmp <- withr::local_tempdir()
+  file.create(file.path(tmp, "foo.Rproj"))
+  dir.create(file.path(tmp, ".Rproj.user"))
+  dir.create(file.path(tmp, ".git"))
+  file.create(file.path(tmp, ".Rhistory"))
+  file.create(file.path(tmp, ".gitignore"))
+
+  expect_no_error(orderly_init_quietly(tmp))
+  expect_true(file.exists(file.path(tmp, ".outpack")))
+  expect_true(file.exists(file.path(tmp, "orderly_config.yml")))
+})
+
+
+test_that("force initialisation of non-empty directory", {
+  tmp <- tempfile()
+  fs::dir_create(tmp)
+  on.exit(unlink(tmp, recursive = TRUE))
+  file.create(file.path(tmp, "file"))
+  expect_no_error(orderly_init_quietly(tmp, force = TRUE))
+  expect_true(file.exists(file.path(tmp, ".outpack")))
+  expect_true(file.exists(file.path(tmp, "orderly_config.yml")))
+})


### PR DESCRIPTION
This PR allows initialising an orderly repo in a nonempty directory, whitelisting some files and also adding a `force` argument that can be used to just create things regardless