### PR TITLE
Better handling of failed push due to corrupt packets

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: orderly2
 Title: Orderly Next Generation
-Version: 1.99.14
+Version: 1.99.15
 Authors@R: c(person("Rich", "FitzJohn", role = c("aut", "cre"),
                     email = "rich.fitzjohn@gmail.com"),
              person("Robert", "Ashton", role = "aut"),

--- a/R/location.R
+++ b/R/location.R
@@ -392,8 +392,14 @@ orderly_location_push <- function(packet_id, location, root = NULL,
   if (length(plan$files) > 0 || length(plan$packet_id) > 0) {
     driver <- location_driver(location_name, root)
     for (hash in plan$files) {
-      ## TODO: mrc-4505 - needs work
-      driver$push_file(find_file_by_hash(root, hash), hash)
+      src <- find_file_by_hash(root, hash)
+      if (is.null(src)) {
+        cli::cli_abort(
+          c("Did not find suitable file, can't push this packet",
+            i = paste("The original file has been changed or deleted.",
+                      "Details are above")))
+      }
+      driver$push_file(src, hash)
     }
     for (id in plan$packet_id) {
       path <- file.path(root$path, ".outpack", "metadata", id)

--- a/tests/testthat/test-location-path.R
+++ b/tests/testthat/test-location-path.R
@@ -350,3 +350,21 @@ test_that("Can read metadata files with a trailing newline", {
   expected_hash <- packets[packets$packet == id]$hash
   expect_no_error(hash_validate_data(data, expected_hash))
 })
+
+
+test_that("Fail to push sensibly if files have been changed", {
+  client <- create_temporary_root()
+  ids <- create_random_packet_chain(client, 4)
+
+  server <- create_temporary_root(use_file_store = TRUE, path_archive = NULL)
+  orderly_location_add("server", "path", list(path = server$path),
+                       root = client)
+
+  ## Corrupt one file:
+  path <- file.path(client$path, "archive", "b", ids[["b"]], "script.R")
+  append_lines(path, "# anything")
+
+  expect_error(
+    suppressMessages(orderly_location_push(ids[[4]], "server", client)),
+    "Did not find suitable file, can't push this packet")
+})


### PR DESCRIPTION
This does not actually **cope** with this situation any better, but it prints the hashes and does not error while reporting the error, which was the previous behaviour.