### PR TITLE
Use vendored libgit2 in outpack_server on CI.

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -52,7 +52,7 @@ jobs:
       - name: setup server
         if: runner.os != 'macOS'
         run: |
-          cargo install --git https://github.com/mrc-ide/outpack_server --branch main --locked
+          cargo install --git https://github.com/mrc-ide/outpack_server --branch main --locked --features git2/vendored-libgit2
 
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:


### PR DESCRIPTION
For some reason the CI has started failing on Windows because of libgit2 linking errors. Using a vendored libgit2 fixes the problem.

Normally libgit2-sys' build scripts should be clever ever to vendor it when needed automatically, but for some reason that's not working and I don't have the patience to figure out why right now. Using the vendored version everywhere is the simplest fix.