### PR TITLE
Optional verbose output for orderly_location_list

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: orderly2
 Title: Orderly Next Generation
-Version: 1.99.23
+Version: 1.99.24
 Authors@R: c(person("Rich", "FitzJohn", role = c("aut", "cre"),
                     email = "rich.fitzjohn@gmail.com"),
              person("Robert", "Ashton", role = "aut"),
@@ -11,7 +11,7 @@ Description: Reimplementation of orderly based on outpack.
 License: MIT + file LICENSE
 Encoding: UTF-8
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.3.1
+RoxygenNote: 7.3.2
 URL: https://github.com/mrc-ide/orderly2
 BugReports: https://github.com/mrc-ide/orderly2/issues
 Imports:

--- a/R/location.R
+++ b/R/location.R
@@ -203,18 +203,31 @@ orderly_location_remove <- function(name, root = NULL, locate = TRUE) {
 ##'
 ##' @inheritParams orderly_metadata
 ##'
-##' @return A character vector of location names. The special name
-##'   `local` will always be present.
+##' @param verbose Logical, indicating if we should return a
+##'   data.frame that includes more information about the location.
+##'
+##' @return Depending on the value of `verbose`:
+##'
+##' * `verbose = FALSE`: A character vector of location names. The
+##'   special name `local` will always be present.  This is the
+##'   default behaviour.
+##' * `verbose = TRUE`: A data.frame with columns `name`, `type` and
+##'   `args`.  The `args` column is a list column, with each element
+##'   being the key-value pair arguments to the location.
 ##'
 ##' @seealso [orderly2::orderly_location_pull_metadata], which can
 ##'   update your outpack index with metadata from any of the
 ##'   locations listed here.
 ##'
 ##' @export
-orderly_location_list <- function(root = NULL, locate = TRUE) {
+orderly_location_list <- function(verbose = FALSE, root = NULL, locate = TRUE) {
   root <- root_open(root, locate = locate, require_orderly = FALSE,
                     call = environment())
-  root$config$location$name
+  if (verbose) {
+    root$config$location
+  } else {
+    root$config$location$name
+  }
 }
 
 
@@ -567,10 +580,10 @@ location_resolve_valid <- function(location, root, include_local,
                                    include_orphan, allow_no_locations,
                                    call = NULL) {
   if (is.null(location)) {
-    location <- orderly_location_list(root)
+    location <- orderly_location_list(root = root)
   } else if (is.character(location)) {
-    valid <- orderly_location_list(root)
-    err <- setdiff(location, orderly_location_list(root))
+    valid <- orderly_location_list(root = root)
+    err <- setdiff(location, orderly_location_list(root = root))
     if (length(err) > 0) {
       cli::cli_abort(c("Unknown location{?s}: {squote(err)}",
                        i = "Valid location{?s} are: {squote(valid)}"),
@@ -783,7 +796,7 @@ location_check_new_name <- function(root, name, call) {
 
 location_check_exists <- function(root, name, call) {
   if (!location_exists(root, name)) {
-    valid <- orderly_location_list(root)
+    valid <- orderly_location_list(root = root)
     cli::cli_abort(c("No location with name '{name}' exists",
                      i = "Possible location{?s} are: {squote(valid)}"),
                    call = call)
@@ -792,7 +805,7 @@ location_check_exists <- function(root, name, call) {
 
 
 location_exists <- function(root, name) {
-  name %in% orderly_location_list(root)
+  name %in% orderly_location_list(root = root)
 }
 
 

--- a/R/location.R
+++ b/R/location.R
@@ -197,7 +197,10 @@ orderly_location_remove <- function(name, root = NULL, locate = TRUE) {
 }
 
 
-##' List known locations.
+##' List known locations.  The special name `local` will always be
+##' present within the output from this function (this is packets
+##' known at the current root), though you will typically be
+##' interested in *other* locations.
 ##'
 ##' @title List known pack locations
 ##'
@@ -208,8 +211,7 @@ orderly_location_remove <- function(name, root = NULL, locate = TRUE) {
 ##'
 ##' @return Depending on the value of `verbose`:
 ##'
-##' * `verbose = FALSE`: A character vector of location names. The
-##'   special name `local` will always be present.  This is the
+##' * `verbose = FALSE`: A character vector of location names.  This is the
 ##'   default behaviour.
 ##' * `verbose = TRUE`: A data.frame with columns `name`, `type` and
 ##'   `args`.  The `args` column is a list column, with each element

--- a/man/orderly_location_list.Rd
+++ b/man/orderly_location_list.Rd
@@ -25,8 +25,7 @@ parents until it finds an \code{.outpack} directory or
 \value{
 Depending on the value of \code{verbose}:
 \itemize{
-\item \code{verbose = FALSE}: A character vector of location names. The
-special name \code{local} will always be present.  This is the
+\item \code{verbose = FALSE}: A character vector of location names.  This is the
 default behaviour.
 \item \code{verbose = TRUE}: A data.frame with columns \code{name}, \code{type} and
 \code{args}.  The \code{args} column is a list column, with each element
@@ -34,7 +33,10 @@ being the key-value pair arguments to the location.
 }
 }
 \description{
-List known locations.
+List known locations.  The special name \code{local} will always be
+present within the output from this function (this is packets
+known at the current root), though you will typically be
+interested in \emph{other} locations.
 }
 \seealso{
 \link{orderly_location_pull_metadata}, which can

--- a/man/orderly_location_list.Rd
+++ b/man/orderly_location_list.Rd
@@ -4,9 +4,12 @@
 \alias{orderly_location_list}
 \title{List known pack locations}
 \usage{
-orderly_location_list(root = NULL, locate = TRUE)
+orderly_location_list(verbose = FALSE, root = NULL, locate = TRUE)
 }
 \arguments{
+\item{verbose}{Logical, indicating if we should return a
+data.frame that includes more information about the location.}
+
 \item{root}{The path to the root directory, or \code{NULL} (the
 default) to search for one from the current working directory if
 \code{locate} is \code{TRUE}. This function does not require that the
@@ -20,8 +23,15 @@ parents until it finds an \code{.outpack} directory or
 \code{orderly_config.yml}}
 }
 \value{
-A character vector of location names. The special name
-\code{local} will always be present.
+Depending on the value of \code{verbose}:
+\itemize{
+\item \code{verbose = FALSE}: A character vector of location names. The
+special name \code{local} will always be present.  This is the
+default behaviour.
+\item \code{verbose = TRUE}: A data.frame with columns \code{name}, \code{type} and
+\code{args}.  The \code{args} column is a list column, with each element
+being the key-value pair arguments to the location.
+}
 }
 \description{
 List known locations.

--- a/tests/testthat/test-location.R
+++ b/tests/testthat/test-location.R
@@ -1,6 +1,11 @@
 test_that("No locations except local by default", {
   root <- create_temporary_root()
   expect_equal(orderly_location_list(root = root), "local")
+  expect_equal(
+    orderly_location_list(TRUE, root = root),
+    data_frame(name = "local",
+               type = "local",
+               args = I(list(set_names(list(), character())))))
 })
 
 
@@ -15,6 +20,13 @@ test_that("Can add a location", {
 
   orderly_location_add("c", "path", list(path = root$c$path), root = root$a)
   expect_setequal(orderly_location_list(root = root$a), c("local", "b", "c"))
+
+  res <- orderly_location_list(verbose = TRUE, root = root$a)
+  expect_equal(res$name, c("local", "b", "c"))
+  expect_equal(res$type, c("local", "path", "path"))
+  expect_equal(res$args, I(list(set_names(list(), character()),
+                                list(path = root$b$path),
+                                list(path = root$c$path))))
 })
 
 

--- a/tests/testthat/test-outpack-root.R
+++ b/tests/testthat/test-outpack-root.R
@@ -11,7 +11,7 @@ test_that("can create new root", {
                        require_complete_tree = FALSE,
                        hash_algorithm = "sha256"))
   expect_false(file.exists(file.path(path, ".outpack", "files")))
-  expect_equal(orderly_location_list(root), "local")
+  expect_equal(orderly_location_list(root = root), "local")
 })
 
 


### PR DESCRIPTION
This PR adds support for returning verbose information about which locations are configured.  This means that the return type of the function varies on an argument which is not great, but I think it's nicer than two functions.  For the 'verbose' output we already hold a data.frame with exactly the information that might be wanted so we return this.  There's some noise as all calls to `orerly_location_list(root)` without naming the `root` argument failed