### PR TITLE
Replace uses of `fs::file_copy` with `file.copy`.

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: orderly2
 Title: Orderly Next Generation
-Version: 1.99.24
+Version: 1.99.25
 Authors@R: c(person("Rich", "FitzJohn", role = c("aut", "cre"),
                     email = "rich.fitzjohn@gmail.com"),
              person("Robert", "Ashton", role = "aut"),

--- a/R/location_path.R
+++ b/R/location_path.R
@@ -44,7 +44,7 @@ orderly_location_path <- R6::R6Class(
           stop(sprintf("Hash '%s' not found at location", hash))
         }
       }
-      fs::file_copy(path, dest, overwrite = TRUE)
+      copy_files(path, dest, overwrite = TRUE)
       dest
     },
 

--- a/R/metadata.R
+++ b/R/metadata.R
@@ -170,7 +170,8 @@ orderly_resource <- function(files) {
   files_expanded <- expand_dirs(files, src)
   if (!is.null(p)) {
     if (p$orderly2$strict$enabled) {
-      copy_files(src, p$path, files_expanded)
+      copy_files(file.path(src, files_expanded),
+                 file.path(p$path, files_expanded))
     } else {
       ## Above we're looking in the underlying source directory, here
       ## we're looking within the running directory; it's not obvious
@@ -408,7 +409,7 @@ copy_shared_resource <- function(path_root, path_dest, config, files, call) {
     there <- replace_ragged(there, is_dir, Map(file.path, there[is_dir], files))
   }
   if (any(!is_dir)) {
-    fs::file_copy(src[!is_dir], dst[!is_dir], overwrite = TRUE)
+    copy_files(src[!is_dir], dst[!is_dir], overwrite = TRUE)
   }
 
   data_frame(here = here, there = there)

--- a/R/outpack_root.R
+++ b/R/outpack_root.R
@@ -70,13 +70,11 @@ file_export <- function(root, id, there, here, dest, overwrite, call = NULL) {
             call = call)
         })
     }
-    fs::file_copy(there_full, here_full, overwrite)
-  }
 
-  # Files in the archive and file store are (generally) read-only.
-  # When exporting for interactive use, it's easier on the user if we make them
-  # writable again.
-  fs::file_chmod(here_full, "u+w")
+    # Set copy.mode = FALSE: files in the archive are read-only. It's easier on
+    # the user if we make them writable again.
+    copy_files(there_full, here_full, overwrite = overwrite, copy.mode = FALSE)
+  }
 }
 
 
@@ -109,8 +107,12 @@ file_import_archive <- function(root, path, file_path, name, id) {
   ## store version, but not of orderly.
   file_path_dest <- file.path(dest, file_path)
   fs::dir_create(dirname(file_path_dest))
+
   ## overwrite = FALSE; see assertion above
-  fs::file_copy(file.path(path, file_path), file_path_dest, overwrite = FALSE)
+  copy_files(file.path(path, file_path),
+             file_path_dest,
+             overwrite = FALSE)
+
   if (length(file_path_dest) > 0) {
     fs::file_chmod(file_path_dest, "a-w")
   }

--- a/R/outpack_root.R
+++ b/R/outpack_root.R
@@ -71,9 +71,9 @@ file_export <- function(root, id, there, here, dest, overwrite, call = NULL) {
         })
     }
 
-    # Set copy.mode = FALSE: files in the archive are read-only. It's easier on
+    # Set copy_mode = FALSE: files in the archive are read-only. It's easier on
     # the user if we make them writable again.
-    copy_files(there_full, here_full, overwrite = overwrite, copy.mode = FALSE)
+    copy_files(there_full, here_full, overwrite = overwrite, copy_mode = FALSE)
   }
 }
 

--- a/R/outpack_store.R
+++ b/R/outpack_store.R
@@ -34,9 +34,9 @@ file_store <- R6::R6Class(
       }
       fs::dir_create(dirname(dst))
 
-      # Set copy.mode = FALSE: files in the store are read-only. It's easier on
+      # Set copy_mode = FALSE: files in the store are read-only. It's easier on
       # the user if we make them writable again.
-      copy_files(src, dst, overwrite = overwrite, copy.mode = FALSE)
+      copy_files(src, dst, overwrite = overwrite, copy_mode = FALSE)
 
       invisible(dst)
     },

--- a/R/outpack_store.R
+++ b/R/outpack_store.R
@@ -33,7 +33,11 @@ file_store <- R6::R6Class(
         stop(not_found_error(message, missing))
       }
       fs::dir_create(dirname(dst))
-      fs::file_copy(src, dst, overwrite)
+
+      # Set copy.mode = FALSE: files in the store are read-only. It's easier on
+      # the user if we make them writable again.
+      copy_files(src, dst, overwrite = overwrite, copy.mode = FALSE)
+
       invisible(dst)
     },
 
@@ -55,7 +59,7 @@ file_store <- R6::R6Class(
         if (move) {
           fs::file_move(src, dst)
         } else {
-          fs::file_copy(src, dst, overwrite = FALSE)
+          copy_files(src, dst, overwrite = FALSE)
         }
         fs::file_chmod(dst, "a-w")
       } else if (move) {

--- a/R/run.R
+++ b/R/run.R
@@ -194,7 +194,7 @@ orderly_run <- function(name, parameters = NULL, envir = NULL, echo = TRUE,
 
   if (dat$strict$enabled) {
     inputs_info <- NULL
-    fs::file_copy(file.path(src, entrypoint_filename), path)
+    copy_files(file.path(src, entrypoint_filename), path)
   } else {
     inputs_info <- copy_resources_implicit(src, path, dat$resources,
                                            dat$artefacts)
@@ -471,10 +471,11 @@ copy_resources_implicit <- function(src, dst, resources, artefacts) {
       to_copy <- setdiff(to_copy, exclude)
     }
   }
-  fs::dir_create(unique(file.path(dst, dirname(to_copy))))
-  fs::file_copy(file.path(src, to_copy),
-                file.path(dst, to_copy),
-                overwrite = TRUE)
+
+  copy_files(file.path(src, to_copy),
+             file.path(dst, to_copy),
+             overwrite = TRUE)
+
   withr::with_dir(dst, fs::file_info(to_copy))
 }
 

--- a/R/util.R
+++ b/R/util.R
@@ -151,11 +151,16 @@ expand_dirs <- function(paths, workdir) {
 }
 
 
-copy_files <- function(src, dst, files, overwrite = FALSE) {
-  fs::dir_create(unique(file.path(dst, dirname(files))))
-  fs::file_copy(file.path(src, files),
-                file.path(dst, files),
-                overwrite = overwrite)
+copy_files <- function(src, dst, overwrite = FALSE,
+                       copy.mode = TRUE) {
+  fs::dir_create(unique(dirname(dst)))
+
+  # mrc-5557: We intentionally don't use fs::file_copy, as it does not work
+  # reliably on mounted Samba file systems.
+  ok <- file.copy(src, dst, overwrite = overwrite, copy.mode = copy.mode)
+  if (any(!ok)) {
+    cli::cli_abort("Could not copy file{?s} {.file {src[!ok]}}")
+  }
 }
 
 

--- a/R/util.R
+++ b/R/util.R
@@ -152,12 +152,12 @@ expand_dirs <- function(paths, workdir) {
 
 
 copy_files <- function(src, dst, overwrite = FALSE,
-                       copy.mode = TRUE) {
+                       copy_mode = TRUE) {
   fs::dir_create(unique(dirname(dst)))
 
   # mrc-5557: We intentionally don't use fs::file_copy, as it does not work
   # reliably on mounted Samba file systems.
-  ok <- file.copy(src, dst, overwrite = overwrite, copy.mode = copy.mode)
+  ok <- file.copy(src, dst, overwrite = overwrite, copy.mode = copy_mode)
   if (any(!ok)) {
     cli::cli_abort("Could not copy file{?s} {.file {src[!ok]}}")
   }

--- a/R/util.R
+++ b/R/util.R
@@ -157,7 +157,9 @@ copy_files <- function(src, dst, overwrite = FALSE,
 
   # mrc-5557: We intentionally don't use fs::file_copy, as it does not work
   # reliably on mounted Samba file systems.
-  ok <- file.copy(src, dst, overwrite = overwrite, copy.mode = copy_mode)
+  ok <- file.copy(src, dst, overwrite = overwrite,
+                  copy.mode = copy_mode,
+                  copy.date = TRUE)
   if (any(!ok)) {
     cli::cli_abort("Could not copy file{?s} {.file {src[!ok]}}")
   }


### PR DESCRIPTION
Unfortunately `fs::file_copy` has issues when working with read-only files on a Samba mounted file system. `file.copy` doesn't have the same problem. See mrc-5557 for more details.

This was tested manually and confirmed to work by running a basic report with an `orderly_dependency` call on a Samba mount. Unfortunately it is not something we can easily test for automatically.