### PR TITLE
Improve handling of non-JSON errors.

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: orderly2
 Title: Orderly Next Generation
-Version: 1.99.26
+Version: 1.99.27
 Authors@R: c(person("Rich", "FitzJohn", role = c("aut", "cre"),
                     email = "rich.fitzjohn@gmail.com"),
              person("Robert", "Ashton", role = "aut"),

--- a/tests/testthat/helper-outpack-http.R
+++ b/tests/testthat/helper-outpack-http.R
@@ -2,7 +2,7 @@ mock_headers <- function(...) {
   structure(list(...), class = c("insensitive", "list"))
 }
 
-mock_response <- function(content, status = 200, wrap = TRUE, download = NULL) {
+mock_response <- function(content, status = 200L, wrap = TRUE, download = NULL) {
   headers <- mock_headers()
   if (!is.null(download)) {
     headers <- mock_headers("content-type" = "application/octet-stream")
@@ -14,6 +14,9 @@ mock_response <- function(content, status = 200, wrap = TRUE, download = NULL) {
                          content)
     }
     class(content) <- NULL
+    content <- c(writeBin(content, raw()), as.raw(0L))
+  } else if (inherits(content, "character")) {
+    headers <- mock_headers("content-type" = "text/plain")
     content <- c(writeBin(content, raw()), as.raw(0L))
   } else {
     stop("Unhandled mock response type")

--- a/tests/testthat/helper-outpack-http.R
+++ b/tests/testthat/helper-outpack-http.R
@@ -2,7 +2,8 @@ mock_headers <- function(...) {
   structure(list(...), class = c("insensitive", "list"))
 }
 
-mock_response <- function(content, status = 200L, wrap = TRUE, download = NULL) {
+mock_response <- function(content, status = 200L, wrap = TRUE,
+                          download = NULL) {
   headers <- mock_headers()
   if (!is.null(download)) {
     headers <- mock_headers("content-type" = "application/octet-stream")

--- a/tests/testthat/test-outpack-http-client.R
+++ b/tests/testthat/test-outpack-http-client.R
@@ -53,7 +53,7 @@ test_that("handle errors", {
     '{"status":"failure",',
     '"errors":[{"error":"NOT_FOUND","detail":"Resource not found"}],',
     '"data":null}')
-  r <-  mock_response(json_string(str), status = 404, wrap = FALSE)
+  r <-  mock_response(json_string(str), status = 404L, wrap = FALSE)
   err <- expect_error(http_client_handle_error(r),
                       "Resource not found")
   expect_s3_class(err, "outpack_http_client_error")
@@ -68,13 +68,22 @@ test_that("handle errors from packit", {
     '{"status":"failure",',
     '"error":{"error":"NOT_FOUND","detail":"Resource not found"},',
     '"data":null}')
-  r <-  mock_response(json_string(str), status = 404, wrap = FALSE)
+  r <-  mock_response(json_string(str), status = 404L, wrap = FALSE)
   err <- expect_error(http_client_handle_error(r),
                       "Resource not found")
   expect_s3_class(err, "outpack_http_client_error")
   expect_equal(err$code, 404)
   expect_equal(err$errors, list(list(error = "NOT_FOUND",
                                      detail = "Resource not found")))
+})
+
+
+test_that("handle plain text errors", {
+  r <- mock_response("foobar", status = 503L, wrap = FALSE)
+  err <- expect_error(http_client_handle_error(r),
+                      "Server error: \\(503\\) Service Unavailable")
+  expect_s3_class(err, "outpack_http_client_error")
+  expect_equal(err$code, 503)
 })
 
 


### PR DESCRIPTION
When getting a non-200 HTTP response, orderly tries to decode the body as JSON in order to extract the error message. We do however occasionally get errors that aren't JSON formatted, in particular if the error is generated by nginx rather than Packit.

This situation can arise if the Packit server is down (a 503 error), or if nginx rejects the request due to the body being too large (a 413 error).

We can use the content type header of the response to determine whether it is safe to decode the body as JSON. If the response is not of the expected mime-type, the body is ignored and a generic error based on the status code alone is returned.