### PR TITLE
Implement OAuth device flow for GitHub logins.

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: orderly2
 Title: Orderly Next Generation
-Version: 1.99.37
+Version: 1.99.38
 Authors@R: c(person("Rich", "FitzJohn", role = c("aut", "cre"),
                     email = "rich.fitzjohn@gmail.com"),
              person("Robert", "Ashton", role = "aut"),

--- a/R/location.R
+++ b/R/location.R
@@ -41,8 +41,8 @@
 ##' * `url`: The location of the server
 ##'
 ##' * `token`: The value for your your login token (currently this is
-##'   a GitHub token with `read:org` scope).  Later we'll expand this
-##'   as other authentication modes are supported.
+##'   a GitHub token with `read:org` scope). If missing or NULL, orderly2 will
+##'   perform an interactive authentication against GitHub to obtain one.
 ##'
 ##' **Custom locations**:
 ##'
@@ -110,6 +110,7 @@ orderly_location_add <- function(name, type, args, root = NULL, locate = TRUE) {
     assert_scalar_character(loc$args[[1]]$url, name = "args$url",
                             call = environment())
     assert_scalar_character(loc$args[[1]]$token, name = "args$token",
+                            allow_null = TRUE,
                             call = environment())
   }
 
@@ -764,7 +765,7 @@ new_location_entry <- function(name, type, args, call = NULL) {
   } else if (type == "http") {
     required <- "url"
   } else if (type == "packit") {
-    required <- c("url", "token")
+    required <- c("url")
   } else if (type == "custom") {
     required <- "driver"
   }

--- a/R/location.R
+++ b/R/location.R
@@ -765,7 +765,7 @@ new_location_entry <- function(name, type, args, call = NULL) {
   } else if (type == "http") {
     required <- "url"
   } else if (type == "packit") {
-    required <- c("url")
+    required <- "url"
   } else if (type == "custom") {
     required <- "driver"
   }

--- a/R/location_http.R
+++ b/R/location_http.R
@@ -6,8 +6,8 @@ orderly_location_http <- R6::R6Class(
   ),
 
   public = list(
-    initialize = function(url, auth = NULL) {
-      private$client <- outpack_http_client$new(url, auth)
+    initialize = function(url, authorise = NULL) {
+      private$client <- outpack_http_client$new(url, authorise)
     },
 
     list = function() {
@@ -86,26 +86,3 @@ orderly_location_http <- R6::R6Class(
     }
   )
 )
-
-
-orderly_location_packit <- function(url, token) {
-  assert_scalar_character(url)
-  assert_scalar_character(token)
-  if (grepl("^\\$", token)) {
-    token_variable <- sub("^\\$", "", token)
-    token <- Sys.getenv(token_variable, NA_character_)
-    if (is.na(token)) {
-      cli::cli_abort(
-        "Environment variable '{token_variable}' was not set")
-    }
-  }
-
-  if (!grepl("/$", url)) {
-    url <- paste0(url, "/")
-  }
-  url_login <- paste0(url, "packit/api/auth/login/api")
-  url_outpack <- paste0(url, "packit/api/outpack")
-
-  auth <- list(url = url_login, data = list(token = scalar(token)))
-  orderly_location_http$new(url_outpack, auth)
-}

--- a/R/location_http.R
+++ b/R/location_http.R
@@ -1,17 +1,15 @@
 orderly_location_http <- R6::R6Class(
   "orderly_location_http",
 
-  private = list(
-    client = NULL
-  ),
-
   public = list(
+    client = NULL,
+
     initialize = function(url, authorise = NULL) {
-      private$client <- outpack_http_client$new(url, authorise)
+      self$client <- outpack_http_client$new(url, authorise)
     },
 
     list = function() {
-      dat <- private$client$request("/metadata/list")$data
+      dat <- self$client$request("/metadata/list")$data
       data_frame(
         packet = vcapply(dat, "[[", "packet"),
         time = num_to_time(vnapply(dat, "[[", "time")),
@@ -21,8 +19,8 @@ orderly_location_http <- R6::R6Class(
     metadata = function(packet_ids) {
       ret <- vcapply(packet_ids, function(id) {
         tryCatch(
-          trimws(private$client$request(sprintf("/metadata/%s/text", id),
-                                        parse_json = FALSE)),
+          trimws(self$client$request(sprintf("/metadata/%s/text", id),
+                                     parse_json = FALSE)),
           outpack_http_client_error = function(e) {
             if (e$code == 404) {
               e$message <- sprintf("Some packet ids not found: '%s'", id)
@@ -43,7 +41,7 @@ orderly_location_http <- R6::R6Class(
       ## progress in the client, but there's not much point until
       ## then.
       tryCatch(
-        private$client$request(sprintf("/file/%s", hash), download = dest),
+        self$client$request(sprintf("/file/%s", hash), download = dest),
         outpack_http_client_error = function(e) {
           if (e$code == 404) {
             unlink(dest)
@@ -56,21 +54,21 @@ orderly_location_http <- R6::R6Class(
 
     ## TODO: we could get the schemas here from outpack_server too
     list_unknown_packets = function(ids) {
-      res <- private$client$request(
+      res <- self$client$request(
         "/packets/missing",
         function(r) http_body_json(r, list(ids = ids, unpacked = scalar(TRUE))))
       list_to_character(res$data)
     },
 
     list_unknown_files = function(hashes) {
-      res <- private$client$request(
+      res <- self$client$request(
         "/files/missing",
         function(r) http_body_json(r, list(hashes = hashes)))
       list_to_character(res$data)
     },
 
     push_file = function(src, hash) {
-      res <- private$client$request(
+      res <- self$client$request(
         sprintf("/file/%s", hash),
         function(r) httr2::req_body_file(r, src, "application/octet-stream"))
 
@@ -79,7 +77,7 @@ orderly_location_http <- R6::R6Class(
 
     push_metadata = function(packet_id, hash, path) {
       meta <- read_string(path)
-      res <- private$client$request(
+      res <- self$client$request(
         sprintf("/packet/%s", hash),
         function(r) httr2::req_body_raw(r, meta, "text/plain"))
       invisible(NULL)

--- a/R/location_packit.R
+++ b/R/location_packit.R
@@ -1,0 +1,75 @@
+github_oauth_client <- function() {
+  # Surprisingly, we don't actually need the Client ID here to match the one
+  # used by Packit. It should be fine to hardcode a value regardless of which
+  # server we are talking to.
+  httr2::oauth_client(
+    id = "Ov23liUrbkR0qUtAO1zu",
+    token_url = "https://github.com/login/oauth/access_token",
+    name = "orderly2"
+  )
+}
+
+do_oauth_device_flow <- function(base_url) {
+  res <- httr2::oauth_token_cached(
+    client = github_oauth_client(),
+    flow = httr2::oauth_flow_device,
+    flow_params = list(
+      auth_url = "https://github.com/login/device/code",
+      scope = "read:org"),
+    cache_disk = TRUE)
+  res$access_token
+}
+
+# Logging in with packit is quite slow and we'll want to cache this; but we
+# won't be holding a persistent handle to the root.  So for now at least we'll
+# keep a pool of generated bearer token headers, stored against the hash of the
+# auth details. We only store this on successful login.
+#
+# This does mean there's no way to flush the cache and force a login, but that
+# should hopefully not be that big a problem.  We'll probably want to refresh
+# the tokens from the request anyway.
+#
+# It also means the user cannot easily use two different identities on the same
+# server from within the same session.
+auth_cache <- new.env(parent = emptyenv())
+packit_authorisation <- function(base_url, token) {
+  key <- rlang::hash(list(base_url = base_url, token = token))
+
+  if (is.null(auth_cache[[key]])) {
+    cli::cli_alert_info("Logging in to {base_url}")
+    if (is.null(token)) {
+      token <- do_oauth_device_flow(base_url)
+    }
+
+    login_url <- paste0(base_url, "packit/api/auth/login/api")
+    res <- http_client_request(
+      login_url,
+      function(r) r %>% httr2::req_body_json(list(token = scalar(token))))
+
+    cli::cli_alert_success("Logged in successfully")
+
+    auth_cache[[key]] <- list("Authorization" = paste("Bearer", res$token))
+  }
+  auth_cache[[key]]
+}
+
+orderly_location_packit <- function(url, token) {
+  assert_scalar_character(url)
+  assert_scalar_character(token, allow_null = TRUE)
+  if (!is.null(token) && grepl("^\\$", token)) {
+    token_variable <- sub("^\\$", "", token)
+    token <- Sys.getenv(token_variable, NA_character_)
+    if (is.na(token)) {
+      cli::cli_abort(
+        "Environment variable '{token_variable}' was not set")
+    }
+  }
+
+  if (!grepl("/$", url)) {
+    url <- paste0(url, "/")
+  }
+
+  orderly_location_http$new(
+    paste0(url, "packit/api/outpack"),
+    function() packit_authorisation(url, token))
+}

--- a/R/location_packit.R
+++ b/R/location_packit.R
@@ -44,7 +44,7 @@ packit_authorisation <- function(base_url, token) {
     login_url <- paste0(base_url, "packit/api/auth/login/api")
     res <- http_client_request(
       login_url,
-      function(r) r %>% httr2::req_body_json(list(token = scalar(token))))
+      function(r) r %>% http_body_json(list(token = scalar(token))))
 
     cli::cli_alert_success("Logged in successfully")
 

--- a/R/location_packit.R
+++ b/R/location_packit.R
@@ -10,13 +10,23 @@ github_oauth_client <- function() {
 }
 
 do_oauth_device_flow <- function(base_url) {
-  res <- httr2::oauth_token_cached(
-    client = github_oauth_client(),
-    flow = httr2::oauth_flow_device,
-    flow_params = list(
-      auth_url = "https://github.com/login/device/code",
-      scope = "read:org"),
-    cache_disk = TRUE)
+  # httr2 has a pretty unintuitive output when running interactively.
+  # It waits for the user to press <Enter> and then opens up a browser, but the
+  # wording isn't super clear. It also does not work at all if a browser can't
+  # be opened, eg. in an SSH session.
+  #
+  # Thankfully, if we pretend to not be interactive the behaviour is a lot more
+  # obvious. It will just print the link to the console and with instructions
+  # for the user to open it up.
+  res <- rlang::with_interactive(value = FALSE, {
+    httr2::oauth_token_cached(
+      client = github_oauth_client(),
+      flow = httr2::oauth_flow_device,
+      flow_params = list(
+        auth_url = "https://github.com/login/device/code",
+        scope = "read:org"),
+      cache_disk = TRUE)
+  })
   res$access_token
 }
 

--- a/R/location_packit.R
+++ b/R/location_packit.R
@@ -44,7 +44,7 @@ packit_authorisation <- function(base_url, token) {
     login_url <- paste0(base_url, "packit/api/auth/login/api")
     res <- http_client_request(
       login_url,
-      function(r) r %>% http_body_json(list(token = scalar(token))))
+      function(r) http_body_json(r, list(token = scalar(token))))
 
     cli::cli_alert_success("Logged in successfully")
 

--- a/R/outpack_http_client.R
+++ b/R/outpack_http_client.R
@@ -3,31 +3,24 @@ outpack_http_client <- R6::R6Class(
 
   public = list(
     url = NULL,
-    auth = NULL,
+    authorise = NULL,
 
-    initialize = function(url, auth) {
+    initialize = function(url, authorise = NULL) {
       self$url <- sub("/$", "", url)
-      if (is.null(auth)) {
-        self$auth <- list(enabled = FALSE)
+      if (is.null(authorise)) {
+        self$authorise <- function() NULL
       } else {
-        self$auth <- list(enabled = TRUE, url = auth$url, data = auth$data)
-      }
-    },
-
-    authorise = function() {
-      needs_auth <- self$auth$enabled && is.null(self$auth$header)
-      if (needs_auth) {
-        self$auth$header <- http_client_login(self$url, self$auth)
+        self$authorise <- authorise
       }
     },
 
     request = function(path, customize = identity, ...) {
-      self$authorise()
+      auth_headers <- self$authorise()
       http_client_request(
         self$url,
         function(r) {
           r <- httr2::req_url_path_append(r, path)
-          r <- httr2::req_headers(r, !!!self$auth$header)
+          r <- httr2::req_headers(r, !!!auth_headers)
           customize(r)
         }, ...)
     }
@@ -92,6 +85,7 @@ http_client_error <- function(msg, code, errors) {
   class(err) <- c("outpack_http_client_error", "error", "condition")
   err
 }
+<<<<<<< HEAD
 
 
 ## Logging in with packit is quite slow and we'll want to cache this;
@@ -118,3 +112,5 @@ http_client_login <- function(name, auth) {
   }
   auth_cache[[key]]
 }
+=======
+>>>>>>> 509a1a1 (Implement OAuth device flow for GitHub logins.)

--- a/R/outpack_http_client.R
+++ b/R/outpack_http_client.R
@@ -85,32 +85,3 @@ http_client_error <- function(msg, code, errors) {
   class(err) <- c("outpack_http_client_error", "error", "condition")
   err
 }
-<<<<<<< HEAD
-
-
-## Logging in with packit is quite slow and we'll want to cache this;
-## but we won't be holding a persistant handle to the root.  So for
-## now at least we'll keep a pool of generated bearer token headers,
-## stored against the hash of the auth details (so the url and the
-## token used to log in with).  We only store this on successful
-## login.
-##
-## This does mean there's no way to flush the cache and force a login,
-## but that should hopefully not be that big a problem.  We'll
-## probably want to refresh the tokens from the request anyway.
-auth_cache <- new.env(parent = emptyenv())
-http_client_login <- function(name, auth) {
-  key <- rlang::hash(auth)
-  if (is.null(auth_cache[[key]])) {
-    cli::cli_alert_info("Logging in to {name}")
-
-    res <- http_client_request(auth$url,
-                               function(r) http_body_json(r, auth$data))
-
-    cli::cli_alert_success("Logged in successfully")
-    auth_cache[[key]] <- list("Authorization" = paste("Bearer", res$token))
-  }
-  auth_cache[[key]]
-}
-=======
->>>>>>> 509a1a1 (Implement OAuth device flow for GitHub logins.)

--- a/man/orderly_location_add.Rd
+++ b/man/orderly_location_add.Rd
@@ -79,8 +79,8 @@ have more capabilities we think.
 \itemize{
 \item \code{url}: The location of the server
 \item \code{token}: The value for your your login token (currently this is
-a GitHub token with \code{read:org} scope).  Later we'll expand this
-as other authentication modes are supported.
+a GitHub token with \code{read:org} scope). If missing or NULL, orderly2 will
+perform an interactive authentication against GitHub to obtain one.
 }
 
 \strong{Custom locations}:

--- a/man/orderly_location_add.Rd
+++ b/man/orderly_location_add.Rd
@@ -81,6 +81,9 @@ have more capabilities we think.
 \item \code{token}: The value for your your login token (currently this is
 a GitHub token with \code{read:org} scope). If missing or NULL, orderly2 will
 perform an interactive authentication against GitHub to obtain one.
+\item \code{save_token}: If no token is provided and interactive authentication is
+used, this controls whether the GitHub token should be saved to disk.
+Defaults to TRUE if missing.
 }
 
 \strong{Custom locations}:

--- a/tests/testthat/helper-outpack-http.R
+++ b/tests/testthat/helper-outpack-http.R
@@ -44,8 +44,8 @@ clear_auth_cache <- function() {
   rm(list = ls(auth_cache), envir = auth_cache)
 }
 
-local_mock_response <- function(..., env = rlang::caller_env()) {
-  mock <- mockery::mock(mock_response(...))
+local_mock_response <- function(..., env = rlang::caller_env(), cycle = FALSE) {
+  mock <- mockery::mock(mock_response(...), cycle = cycle)
   httr2::local_mocked_responses(function(req) mock(req), env = env)
   mock
 }

--- a/tests/testthat/test-location-packit.R
+++ b/tests/testthat/test-location-packit.R
@@ -2,7 +2,7 @@ test_that("can authenticate with existing token", {
   clear_auth_cache()
   withr::defer(clear_auth_cache())
 
-  token = "my-github-token"
+  token <- "my-github-token"
 
   mock_post <- local_mock_response(
     to_json(list(token = jsonlite::unbox("my-packit-token"))),
@@ -22,7 +22,7 @@ test_that("can authenticate with existing token", {
   expect_equal(args[[1]]$url, "http://example.com/packit/api/auth/login/api")
   expect_equal(args[[1]]$body$data, list(token = scalar("my-github-token")))
   expect_equal(args[[1]]$body$type, "json")
- 
+
   ## And a second time, does not call mock_post again:
   res2 <- expect_silent(
     packit_authorisation("http://example.com/", token))
@@ -42,7 +42,7 @@ test_that("can authenticate using device flow", {
   mockery::stub(packit_authorisation, "do_oauth_device_flow", "my-github-token")
 
   res <- evaluate_promise(packit_authorisation("http://example.com/",
-                                               token=NULL))
+                                               token = NULL))
 
   expect_length(res$messages, 2)
   expect_match(res$messages[[1]], "Logging in to http://example.com")
@@ -61,7 +61,7 @@ test_that("location_packit uses authentication", {
   clear_auth_cache()
   withr::defer(clear_auth_cache())
 
-  token = "my-github-token"
+  token <- "my-github-token"
   id <- outpack_id()
   metadata <- "packet metadata"
 
@@ -90,7 +90,7 @@ test_that("location_packit uses authentication", {
   args <- mockery::mock_args(mock)[[2]]
   expect_match(args[[1]]$url,
                "http://example.com/packit/api/outpack/metadata/.*/text")
-  expect_equal(args[[1]]$headers, 
+  expect_equal(args[[1]]$headers,
                list(Authorization = "Bearer my-packit-token"),
                ignore_attr = TRUE)
 

--- a/tests/testthat/test-location-packit.R
+++ b/tests/testthat/test-location-packit.R
@@ -1,0 +1,127 @@
+test_that("can authenticate with existing token", {
+  clear_auth_cache()
+  withr::defer(clear_auth_cache())
+
+  token = "my-github-token"
+
+  mock_post <- local_mock_response(
+    to_json(list(token = jsonlite::unbox("my-packit-token"))),
+    wrap = FALSE)
+
+  res <- evaluate_promise(
+    packit_authorisation("http://example.com/", token))
+
+  expect_length(res$messages, 2)
+  expect_match(res$messages[[1]], "Logging in to http://example.com")
+  expect_match(res$messages[[2]], "Logged in successfully")
+  expect_equal(res$result,
+               list("Authorization" = paste("Bearer", "my-packit-token")))
+
+  mockery::expect_called(mock_post, 1)
+  args <- mockery::mock_args(mock_post)[[1]]
+  expect_equal(args[[1]]$url, "http://example.com/packit/api/auth/login/api")
+  expect_equal(args[[1]]$body$data, list(token = scalar("my-github-token")))
+  expect_equal(args[[1]]$body$type, "json")
+ 
+  ## And a second time, does not call mock_post again:
+  res2 <- expect_silent(
+    packit_authorisation("http://example.com/", token))
+  expect_equal(res2, res$result)
+  mockery::expect_called(mock_post, 1)
+})
+
+
+test_that("can authenticate using device flow", {
+  clear_auth_cache()
+  withr::defer(clear_auth_cache())
+
+  mock_post <- local_mock_response(
+    to_json(list(token = jsonlite::unbox("my-packit-token"))),
+    wrap = FALSE)
+
+  mockery::stub(packit_authorisation, "do_oauth_device_flow", "my-github-token")
+
+  res <- evaluate_promise(packit_authorisation("http://example.com/",
+                                               token=NULL))
+
+  expect_length(res$messages, 2)
+  expect_match(res$messages[[1]], "Logging in to http://example.com")
+  expect_match(res$messages[[2]], "Logged in successfully")
+  expect_equal(res$result,
+               list("Authorization" = paste("Bearer", "my-packit-token")))
+
+  mockery::expect_called(mock_post, 1)
+  args <- mockery::mock_args(mock_post)[[1]]
+  expect_equal(args[[1]]$url, "http://example.com/packit/api/auth/login/api")
+  expect_equal(args[[1]]$body$data, list(token = scalar("my-github-token")))
+  expect_equal(args[[1]]$body$type, "json")
+})
+
+test_that("location_packit uses authentication", {
+  clear_auth_cache()
+  withr::defer(clear_auth_cache())
+
+  token = "my-github-token"
+  id <- outpack_id()
+  metadata <- "packet metadata"
+
+  mock_login <- mock_response(
+    to_json(list(token = jsonlite::unbox("my-packit-token"))),
+    wrap = FALSE)
+  mock_get <- mock_response(metadata)
+  mock <- mockery::mock(mock_login, mock_get)
+  httr2::local_mocked_responses(function(req) mock(req))
+
+  location <- orderly_location_packit("http://example.com", token)
+  res <- evaluate_promise(location$metadata(id))
+
+  expect_length(res$messages, 2)
+  expect_match(res$messages[[1]], "Logging in to http://example.com")
+  expect_match(res$messages[[2]], "Logged in successfully")
+  expect_equal(res$result, setNames(metadata, id))
+
+  mockery::expect_called(mock, 2)
+
+  args <- mockery::mock_args(mock)[[1]]
+  expect_equal(args[[1]]$url, "http://example.com/packit/api/auth/login/api")
+  expect_equal(args[[1]]$body$data, list(token = scalar("my-github-token")))
+  expect_equal(args[[1]]$body$type, "json")
+
+  args <- mockery::mock_args(mock)[[2]]
+  expect_match(args[[1]]$url,
+               "http://example.com/packit/api/outpack/metadata/.*/text")
+  expect_equal(args[[1]]$headers, 
+               list(Authorization = "Bearer my-packit-token"),
+               ignore_attr = TRUE)
+
+  mock <- mockery::mock(mock_login, mock_get)
+})
+
+test_that("can create a packit location using an environment variable token", {
+  loc <- withr::with_envvar(
+    c("PACKIT_TOKEN" = "abc123"),
+    orderly_location_packit("http://example.com", "$PACKIT_TOKEN"))
+
+  mock_login <- local_mock_response(
+    to_json(list(token = jsonlite::unbox("my-packit-token"))),
+    wrap = FALSE)
+
+  client <- loc$.__enclos_env__$private$client
+  evaluate_promise(client$authorise())
+
+  mockery::expect_called(mock_login, 1)
+
+  args <- mockery::mock_args(mock_login)[[1]]
+  expect_equal(args[[1]]$url, "http://example.com/packit/api/auth/login/api")
+  expect_equal(args[[1]]$body$data, list(token = scalar("abc123")))
+  expect_equal(args[[1]]$body$type, "json")
+})
+
+
+test_that("error of token variable not found", {
+  withr::with_envvar(
+    c("PACKIT_TOKEN" = NA_character_),
+    expect_error(
+      orderly_location_packit("https://example.com", "$PACKIT_TOKEN"),
+      "Environment variable 'PACKIT_TOKEN' was not set"))
+})

--- a/tests/testthat/test-location.R
+++ b/tests/testthat/test-location.R
@@ -816,7 +816,7 @@ test_that("validate arguments to packit locations", {
     orderly_location_add("other", "packit",
                          list(url = "example.com", token = 123),
                          root = root),
-    "'args$token' must be character")
+    "'args$token' must be character", fixed = TRUE)
 
   expect_equal(orderly_location_list(root = root), "local")
 })

--- a/tests/testthat/test-outpack-http-client.R
+++ b/tests/testthat/test-outpack-http-client.R
@@ -145,111 +145,23 @@ test_that("can use the client to make requests", {
 
 
 test_that("can add auth details to the client", {
-  auth <- list(url = "http://example.com/api/login",
-               data = list(token = "mytoken"))
-
-  cl <- outpack_http_client$new("http://example.com", auth)
-
   h <- list("Authorization" = "Bearer yogi")
-  mock_login <- mockery::mock(h, cycle = TRUE)
-  mockery::stub(cl$authorise, "http_client_login", mock_login)
+  mock_authorise <- mockery::mock(h, cycle = TRUE)
 
-  cl$authorise()
+  cl <- outpack_http_client$new("http://example.com", mock_authorise)
 
-  mockery::expect_called(mock_login, 1)
-  expect_equal(
-    mockery::mock_args(mock_login)[[1]],
-    list("http://example.com",
-         list(enabled = TRUE, url = auth$url, data = auth$data)))
-  expect_equal(cl$auth$header, h)
-
-  ## Second call, does not log in
-  cl$authorise()
-  mockery::expect_called(mock_login, 1)
-
-  ## Actually perform an api call now:
   mock_get <- local_mock_response(json_string("[1,2,3]"))
   res <- cl$request("/path")
   expect_mapequal(
     res,
     list(status = "success", errors = NULL, data = list(1, 2, 3)))
 
+  mockery::expect_called(mock_authorise, 1)
   mockery::expect_called(mock_get, 1)
+
   args <- mockery::mock_args(mock_get)[[1]]
   expect_equal(args[[1]]$url, "http://example.com/path")
   expect_equal(args[[1]]$headers,
                list(Authorization = "Bearer yogi"),
-               ignore_attr = TRUE)
-})
-
-
-test_that("can send authentication request", {
-  clear_auth_cache()
-  withr::defer(clear_auth_cache())
-
-  mock_post <- local_mock_response(
-    to_json(list(token = jsonlite::unbox("mytoken"))),
-    wrap = FALSE)
-
-  auth <- list(
-    url = "https://example.com/login",
-    data = list(token = "98e02a382db6a3a18e9d2e02c698478b"))
-
-  res <- evaluate_promise(
-    http_client_login("foo", auth))
-
-  expect_length(res$messages, 2)
-  expect_match(res$messages[[1]], "Logging in to foo")
-  expect_match(res$messages[[2]], "Logged in successfully")
-  expect_equal(res$result, list("Authorization" = paste("Bearer", "mytoken")))
-
-  mockery::expect_called(mock_post, 1)
-  args <- mockery::mock_args(mock_post)[[1]]
-  expect_equal(args[[1]]$url, auth$url)
-  expect_equal(args[[1]]$body$data, list(token = auth$data$token))
-  expect_equal(args[[1]]$body$type, "json")
-
-  ## And a second time, does not call mock_post again:
-  expect_silent(
-    res2 <- http_client_login("foo", auth))
-  expect_equal(res2, res$result)
-  mockery::expect_called(mock_post, 1)
-})
-
-
-test_that("can send authenticated request", {
-  clear_auth_cache()
-  withr::defer(clear_auth_cache())
-
-  mock <- mockery::mock(
-    mock_response(to_json(list(token = jsonlite::unbox("mytoken"))),
-                  wrap = FALSE),
-    mock_response(json_string("[1,2,3]")))
-  httr2::local_mocked_responses(function(req) mock(req))
-
-  auth <- list(
-    url = "https://example.com/api/login",
-    data = list(token = "98e02a382db6a3a18e9d2e02c698478b"))
-
-  cl <- outpack_http_client$new("http://example.com", auth)
-  res <- evaluate_promise(cl$request("data"))
-
-  expect_length(res$messages, 2)
-  expect_match(res$messages[[1]], "Logging in to http://example.com")
-  expect_match(res$messages[[2]], "Logged in successfully")
-  expect_mapequal(
-    res$result,
-    list(status = "success", errors = NULL, data = list(1, 2, 3)))
-
-  mockery::expect_called(mock, 2)
-  post_args <- mockery::mock_args(mock)[[1]]
-  expect_equal(post_args[[1]]$url, auth$url)
-  expect_equal(post_args[[1]]$body$data, list(token = auth$data$token))
-  expect_equal(post_args[[1]]$body$type, "json")
-
-  get_args <- mockery::mock_args(mock)[[2]]
-  expect_equal(get_args[[1]]$url, "http://example.com/data")
-  expect_equal(get_args[[1]]$headers,
-               list(Authorization = paste("Bearer mytoken")),
                ignore_attr = TRUE)
 })


### PR DESCRIPTION
GitHub-based logins to Packit rely on users specifying a personal access token when adding the location. This has a number of usability and security disadvantages.

Users need to manually take steps in order to create a PAT, and they need to make sure they have selected the right scope. It is quite likely users would be tempted to create tokens with way more scopes than is necessary.

The configured PAT would be stored in the orderly configuration, which many users share and keep on network drives that are accessible to everyone.

By using an OAuth flow to generate our own tokens, we remove the extra steps the user needed to take and we can make sure it has just the right scopes needed. Additionally the token cache implemented by httr2 is located outside of the orderly repository, in the user's home directory.

The device flow works by showing the user an 8 character code in the console, and a link to https://github.com/login/device. The user needs to type in the code and approve the login. Meanwhile, the orderly2 client polls the GitHub API until the authentication has been approved.

There are other OAuth flows we could have used, in particular the authorization code flow (with PKCE). In this case, a link is printed to the console and the user needs to follow it and approve the login. They are then redirected to a localhost server, which has been started by orderly2. This removes the need to need with the 8 character code of the device flow, but it is a bit finicky and assumes orderly2 is running on the same machine as the user's browser, which may not be the case when runing over SSH. For this reason, the device flow is preferred.

It is still possible to specify a PAT as before, in which case the OAuth flow is skipped. This can be useful in non-interactive situations, such as a CI pipeline.

Note that there are still fundamental issues with this model. In particular, the Github tokens are not bound to the application. This means that a malicious application could manage to get a user to sign in to it, obtain a access token for the user, and use this to login to Packit. From just a GitHub `read:org` scope, the app is able to escalate to full impersonation of the user on the Packit server.

Additionally it still tightly couples the orderly2 client with GitHub as an authentication method, prohibiting the use of other authentication methods, such as basic username / password.

Ideally we would remove the use of Github Access tokens as a way to login to Packit. Instead, Packit should itself implement an OAuth2 Authorization Server. orderly2 would perform the device flow directly against Packit, and directly retrieve a Packit JWT in exchange. During the device flow, when the user is directed to the Packit website to enter the user code, Packit may require the user to login. When this happens, a new, parallel OAuth flow would take place, this time with GitHub as the OAuth AS and Packit as the OAuth client (using the authorization code flow). When the nested flow is complete and login is succesful, the user would be prompted to type in the code and complete the flow initiated by orderly2.

With this approach, orderly2 has no involvement with GitHub at all, and Packit can use another authentication method (or even no authentication). This would be completely transparent to the orderly2 client. It also provides tighter binding between GitHub and Packit, as Packit fetches the access token directly from the former, and cannot be supplied a token from an arbitrary application.