### PR TITLE
Fix tests on R-devel.

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: orderly2
 Title: Orderly Next Generation
-Version: 1.99.28
+Version: 1.99.29
 Authors@R: c(person("Rich", "FitzJohn", role = c("aut", "cre"),
                     email = "rich.fitzjohn@gmail.com"),
              person("Robert", "Ashton", role = "aut"),

--- a/tests/testthat/test-outpack-root.R
+++ b/tests/testthat/test-outpack-root.R
@@ -100,7 +100,7 @@ test_that("Can work out what packets are missing", {
   for (name in c("a", "b")) {
     root[[name]] <- create_temporary_root()
   }
-  ids <- create_random_packet_chain(root$a, 3)
+  ids <- unname(create_random_packet_chain(root$a, 3))
   orderly_location_add("a", "path", list(path = root$a$path), root = root$b)
   orderly_location_pull_metadata(root = root$b)
 
@@ -118,7 +118,7 @@ test_that("Can work out what packets are missing", {
   expect_equal(root_list_unknown_packets(rev(ids_fake), root$a),
                rev(ids_fake))
 
-  ids_all <- sample(c(unname(ids), ids_fake))
+  ids_all <- sample(c(ids, ids_fake))
   expect_equal(root_list_unknown_packets(ids_all, root$a),
                setdiff(ids_all, ids))
   expect_equal(root_list_unknown_packets(ids_all, root$b),


### PR DESCRIPTION
As of yesterday, the development version of R preserves names in its implementation of `setdiff` (and other set-like operations). This has changed the behaviour of `root_list_unknown_packets` to also preserves names, which broke some tests that were a little too strict about it.

```
$ docker run -it rocker/r-ver:devel R -s -e 'dput(setdiff(c(a=1), NULL))'
c(a = 1)
$ docker run -it rocker/r-ver:4.4 R -s -e 'dput(setdiff(c(a=1), NULL))'
1
```

See https://github.com/r-devel/r-svn/commit/982288a5640ba584ff0d7e6ba85bf566a4184686 for the offending upstream change.