### PR TITLE
Re-enable some integration tests on windows.

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: orderly2
 Title: Orderly Next Generation
-Version: 1.99.29
+Version: 1.99.30
 Authors@R: c(person("Rich", "FitzJohn", role = c("aut", "cre"),
                     email = "rich.fitzjohn@gmail.com"),
              person("Robert", "Ashton", role = "aut"),

--- a/tests/testthat/test-zzz-location-http.R
+++ b/tests/testthat/test-zzz-location-http.R
@@ -94,7 +94,6 @@ describe("http location integration tests", {
   })
 
   it("can push into server", {
-    skip_on_os("windows") # mrc-4442
     root_downstream <- create_temporary_root(use_file_store = TRUE)
     ids_downstream <- create_random_packet_chain(root_downstream, 3)
     orderly_location_add("upstream", "http", list(url = url),
@@ -129,7 +128,6 @@ describe("http location integration tests", {
   })
 
   it("throws sensible error if file hash does not match expected", {
-    skip_on_os("windows") # mrc-4442
     loc <- orderly_location_http$new(url)
 
     tmp <- withr::local_tempfile()


### PR DESCRIPTION
These were disabled when they were introduced, back in mrc-ide/orderly2#42. They seem to work now, possibly thanks to mrc-ide/outpack_server#48, so no need to skip them anymore. We run CI on outpack_server on all platforms these days, so it should be fairly stable.