### PR TITLE
Improve handling of deleted implicit inputs.

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: orderly2
 Title: Orderly Next Generation
-Version: 1.99.30
+Version: 1.99.31
 Authors@R: c(person("Rich", "FitzJohn", role = c("aut", "cre"),
                     email = "rich.fitzjohn@gmail.com"),
              person("Robert", "Ashton", role = "aut"),


### PR DESCRIPTION
In implicit mode, orderly prints a message if some of the implicit inputs have been modified by the report. However the code to enumerate modified files did not properly handle files that have been deleted. When that happens, `fs::file_info` return NA in all the metadata columns.

We now detect these files and display a slightly different warning for it.

Cleaned up a bit of adjacent code: switch from handcrafted bullet points to using `cli::cli_ul`, fixed some tests which had used `suppressMessages` when they could have used `orderly_run_quietly`.