### PR TITLE
Cache builds of outpack_server

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -2,9 +2,9 @@
 # Need help debugging build failures? Start at https://github.com/r-lib/actions#where-to-find-help
 on:
   push:
-    branches: [main, master, epic-poc]
+    branches: [main]
   pull_request:
-    branches: [main, master, epic-poc]
+    branches: [main]
 
 name: R-CMD-check
 
@@ -42,17 +42,16 @@ jobs:
           http-user-agent: ${{ matrix.config.http-user-agent }}
           use-public-rspm: true
 
-      # This does take a minute or two to install, and we could cache
-      # it but that's not super easy while still allowing easy
-      # updating. Once things stabilise we might tag outpack server
-      # releases and then we can install and cache against that.
-      #
-      # This now hangs on macOS, will explore binary builds for the
-      # server in mrc-4515, disabling on mac now.
-      - name: setup server
-        if: runner.os != 'macOS'
-        run: |
-          cargo install --git https://github.com/mrc-ide/outpack_server --branch main --locked --features git2/vendored-libgit2
+      # Compiling outpack server from source takes a few minutes each time.
+      # This action will cache the result and re-use it on subsequent builds.
+      # The cache is keyed by Git revision, allowing us to pick up new versions
+      # of the server immediately.
+      - name: Install outpack server
+        uses: baptiste0928/cargo-install@v3
+        with:
+          crate: outpack
+          git: https://github.com/mrc-ide/outpack_server
+          features: git2/vendored-libgit2
 
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:

--- a/.github/workflows/test-coverage.yaml
+++ b/.github/workflows/test-coverage.yaml
@@ -2,9 +2,9 @@
 # Need help debugging build failures? Start at https://github.com/r-lib/actions#where-to-find-help
 on:
   push:
-    branches: [main, master, epic-poc]
+    branches: [main]
   pull_request:
-    branches: [main, master, epic-poc]
+    branches: [main]
 
 name: test-coverage
 
@@ -21,9 +21,16 @@ jobs:
         with:
           use-public-rspm: true
 
-      - name: setup server
-        run: |
-          cargo install --git https://github.com/mrc-ide/outpack_server --branch main --locked
+      # Compiling outpack server from source takes a few minutes each time.
+      # This action will cache the result and re-use it on subsequent builds.
+      # The cache is keyed by Git revision, allowing us to pick up new versions
+      # of the server immediately.
+      - name: Install outpack server
+        uses: baptiste0928/cargo-install@v3
+        with:
+          crate: outpack
+          git: https://github.com/mrc-ide/outpack_server
+          features: git2/vendored-libgit2
 
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: orderly2
 Title: Orderly Next Generation
-Version: 1.99.31
+Version: 1.99.32
 Authors@R: c(person("Rich", "FitzJohn", role = c("aut", "cre"),
                     email = "rich.fitzjohn@gmail.com"),
              person("Robert", "Ashton", role = "aut"),


### PR DESCRIPTION
Compiling outpack_server each time takes about 2 minutes on Linux and up to 5 minutes on Windows, slowing down our CI jobs. We can cache the resulting binaries to avoid having to do this on every orderly2 build.

The action includes the Git revision of the outpack_server repository in its cache key, meaning we'll automatically pull new versions of the server as they come. Of course we'll need to compile these, but we will only be paying the cost once per new commit, instead of each time. The development rate on outpack_server is low enough that this shouldn't be too cumbersome.

The alternative would be to start tagging releases of outpack_server and publish pre-built binaries of it. It is more effort, both to setup and to use in the future, so simply caching the installation here seems preferable.