### PR TITLE
Propagate name parameter in match_value.

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: orderly2
 Title: Orderly Next Generation
-Version: 1.99.32
+Version: 1.99.33
 Authors@R: c(person("Rich", "FitzJohn", role = c("aut", "cre"),
                     email = "rich.fitzjohn@gmail.com"),
              person("Robert", "Ashton", role = "aut"),

--- a/R/util_assert.R
+++ b/R/util_assert.R
@@ -198,7 +198,7 @@ assert_directory_does_not_exist <- function(x, name = "Directory", arg = NULL,
 
 match_value <- function(x, choices, name = deparse(substitute(x)),
                         arg = name, call = NULL) {
-  assert_scalar_character(x, call = call, arg = arg)
+  assert_scalar_character(x, name = name, arg = arg, call = call)
   if (!(x %in% choices)) {
     cli::cli_abort(
       c("'{name}' must be one of {collapseq(choices)}",


### PR DESCRIPTION
Without this, when the first argument of `match_value` was not a valid character scalar, the function would unconditionally call it `x`, even if the caller's code makes no mention of `x`.

```r
match_value(5, list("foo", "bar"))
#> Error:
#> ! 'x' must be character
```

With this change, the name as used in the caller of `match_value` is used, which gives a less confusing output:

```r
match_value(5, list("foo", "bar"))
#> Error:
#> ! '5' must be character
```