### PR TITLE
Use the fs package to copy files.

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: orderly2
 Title: Orderly Next Generation
-Version: 1.99.38
+Version: 1.99.39
 Authors@R: c(person("Rich", "FitzJohn", role = c("aut", "cre"),
                     email = "rich.fitzjohn@gmail.com"),
              person("Robert", "Ashton", role = "aut"),

--- a/R/outpack_root.R
+++ b/R/outpack_root.R
@@ -107,7 +107,6 @@ file_import_archive <- function(root, path, file_path, name, id) {
   ## some files behind.  This does match the behaviour of the file
   ## store version, but not of orderly.
   file_path_dest <- file.path(dest, file_path)
-  fs::dir_create(dirname(file_path_dest))
 
   ## overwrite = FALSE; see assertion above
   copy_files(file.path(path, file_path),

--- a/R/outpack_root.R
+++ b/R/outpack_root.R
@@ -71,9 +71,10 @@ file_export <- function(root, id, there, here, dest, overwrite, call = NULL) {
         })
     }
 
-    # Set copy_mode = FALSE: files in the archive are read-only. It's easier on
-    # the user if we make them writable again.
-    copy_files(there_full, here_full, overwrite = overwrite, copy_mode = FALSE)
+    # Files in the archive are read-only. It's easier on the user if we make
+    # them writable again.
+    copy_files(there_full, here_full, overwrite = overwrite,
+               make_writable = TRUE)
   }
 }
 

--- a/R/outpack_store.R
+++ b/R/outpack_store.R
@@ -33,9 +33,14 @@ file_store <- R6::R6Class(
         stop(not_found_error(message, missing))
       }
 
-      # Files in the archive are read-only. It's easier on the user if we make
-      # them writable again.
-      copy_files(src, dst, overwrite = overwrite, make_writable = FALSE)
+      copy_files(src, dst, overwrite = overwrite)
+
+      # Files in the store are read-only to avoid accidental corruption.
+      # This is however an implementation detail, and we should export them as
+      # writable again.
+      if (length(dst) > 0) { # https://github.com/r-lib/fs/issues/471
+        fs::file_chmod(dst, "u+w")
+      }
 
       invisible(dst)
     },

--- a/R/outpack_store.R
+++ b/R/outpack_store.R
@@ -32,11 +32,10 @@ file_store <- R6::R6Class(
                            paste(sprintf("  - %s", missing), collapse = "\n"))
         stop(not_found_error(message, missing))
       }
-      fs::dir_create(dirname(dst))
 
-      # Set copy_mode = FALSE: files in the store are read-only. It's easier on
-      # the user if we make them writable again.
-      copy_files(src, dst, overwrite = overwrite, copy_mode = FALSE)
+      # Files in the archive are read-only. It's easier on the user if we make
+      # them writable again.
+      copy_files(src, dst, overwrite = overwrite, make_writable = FALSE)
 
       invisible(dst)
     },

--- a/R/run.R
+++ b/R/run.R
@@ -194,7 +194,8 @@ orderly_run <- function(name, parameters = NULL, envir = NULL, echo = TRUE,
 
   if (dat$strict$enabled) {
     inputs_info <- NULL
-    copy_files(file.path(src, entrypoint_filename), path)
+    copy_files(file.path(src, entrypoint_filename),
+               file.path(path, entrypoint_filename))
   } else {
     inputs_info <- copy_resources_implicit(src, path, dat$resources,
                                            dat$artefacts)
@@ -477,8 +478,7 @@ copy_resources_implicit <- function(src, dst, resources, artefacts) {
   }
 
   copy_files(file.path(src, to_copy),
-             file.path(dst, to_copy),
-             overwrite = TRUE)
+             file.path(dst, to_copy))
 
   withr::with_dir(dst, fs::file_info(to_copy))
 }

--- a/R/util.R
+++ b/R/util.R
@@ -185,16 +185,44 @@ expand_dirs <- function(files, workdir) {
 
 
 copy_files <- function(src, dst, overwrite = FALSE,
-                       copy_mode = TRUE) {
+                       make_writable = FALSE) {
+  assert_character(src)
+  assert_character(dst)
+
+  if (length(src) != length(dst)) {
+    cli::cli_abort("Source and destination have different lengths")
+  }
+
+  is_dir <- fs::dir_exists(dst)
+  if (any(is_dir)) {
+    paths <- dst[is_dir]
+    cli::cli_abort(paste(
+      "Destination path{?s} {?is a directory/are directories}:",
+      "{.path {paths}}"))
+  }
+
   fs::dir_create(unique(dirname(dst)))
 
-  # mrc-5557: We intentionally don't use fs::file_copy, as it does not work
-  # reliably on mounted Samba file systems.
-  ok <- file.copy(src, dst, overwrite = overwrite,
-                  copy.mode = copy_mode,
-                  copy.date = TRUE)
-  if (any(!ok)) {
-    cli::cli_abort("Could not copy file{?s} {.file {src[!ok]}}")
+  # For some reason, file_copy does not work when `overwrite = TRUE`, the
+  # source file is read-only, the destination file is on a Samba file mount,
+  # and we are on Linux. This seems like a bug in the Linux Samba driver.
+  # See mrc-5557 for details.
+  #
+  # We work around it by always passing `overwrite = FALSE`. Instead we delete
+  # any existing files manually beforehand. It is vulnerable to race condition,
+  # as someone could recreate the file between the calls to file_delete and
+  # file_copy, but that seems unlikely.
+  #
+  # If you are going to make changes to this function, make sure to run all
+  # tests with TMPDIR set to a path on a network drive.
+  if (overwrite) {
+    exists <- fs::file_exists(dst)
+    fs::file_delete(dst[exists])
+  }
+
+  fs::file_copy(src, dst, overwrite = FALSE)
+  if (make_writable && length(dst) > 0) {
+    fs::file_chmod(dst, "a+w")
   }
 }
 

--- a/tests/testthat/helper-outpack.R
+++ b/tests/testthat/helper-outpack.R
@@ -184,7 +184,7 @@ outpack_packet_end_quietly <- function(...) {
 
 forcibly_truncate_file <- function(path) {
   permissions <- fs::file_info(path)$permissions
-  fs::file_chmod(path, "a+w")
-  file.create(path)
+  fs::file_delete(path)
+  fs::file_create(path)
   fs::file_chmod(path, permissions)
 }

--- a/tests/testthat/test-outpack-config.R
+++ b/tests/testthat/test-outpack-config.R
@@ -97,14 +97,14 @@ test_that("Can add file_store", {
   expect_equal(length(hash_pulled), 3)
 
   dest <- temp_file()
-  dir.create(dest)
-  root$dst$files$get(hash_pulled[[1]], dest, TRUE)
-  root$dst$files$get(hash_pulled[[2]], dest, TRUE)
-  root$dst$files$get(hash_pulled[[3]], dest, TRUE)
+  root$dst$files$get(hash_pulled[[1]], file.path(dest, "a"), TRUE)
+  root$dst$files$get(hash_pulled[[2]], file.path(dest, "b"), TRUE)
+  root$dst$files$get(hash_pulled[[3]], file.path(dest, "c"), TRUE)
 
   hash_not_pulled <- outpack_metadata_core(id[["a"]], root$dst)$files$hash
-  expect_error(root$dst$files$get(hash_not_pulled[[1]], dest, TRUE),
-               "not found in store")
+  expect_error(
+    root$dst$files$get(hash_not_pulled[[1]], file.path(dest, "d"), TRUE),
+    "not found in store")
 })
 
 
@@ -144,7 +144,6 @@ test_that("Files will be searched for by hash when adding file store", {
   expect_true(root$config$core$use_file_store)
 
   dest <- temp_file()
-  dir.create(dest)
   root$files$get(outpack_metadata_core(id, root)$files$hash, dest, TRUE)
 })
 
@@ -247,10 +246,9 @@ test_that("Can add archive", {
   expect_equal(length(hash), 3)
 
   dest <- temp_file()
-  dir.create(dest)
-  root$files$get(hash[[1]], dest, TRUE)
-  root$files$get(hash[[2]], dest, TRUE)
-  root$files$get(hash[[3]], dest, TRUE)
+  root$files$get(hash[[1]], file.path(dest, "a"), TRUE)
+  root$files$get(hash[[2]], file.path(dest, "b"), TRUE)
+  root$files$get(hash[[3]], file.path(dest, "c"), TRUE)
 })
 
 

--- a/tests/testthat/test-outpack-helpers.R
+++ b/tests/testthat/test-outpack-helpers.R
@@ -8,6 +8,7 @@ test_that("can copy files from outpack", {
   expect_identical(
     readRDS(file.path(dst, "incoming.rds")),
     readRDS(file.path(root$path, "archive", "data", id, "data.rds")))
+  expect_true(fs::file_access(file.path(dst, "incoming.rds"), "write"))
 })
 
 

--- a/tests/testthat/test-outpack-store.R
+++ b/tests/testthat/test-outpack-store.R
@@ -73,3 +73,33 @@ test_that("can create a filename within the store", {
   expect_false(file.exists(p))
   expect_true(file.exists(file.path(obj$path, "tmp")))
 })
+
+
+test_that("files is the store are read-only", {
+  obj <- file_store$new(withr::local_tempdir())
+
+  f <- withr::local_tempfile()
+  writeLines("Hello", f)
+  h <- hash_file(f)
+  obj$put(f, h)
+
+  path <- obj$filename(h)
+  expect_true(fs::file_access(path, "read"))
+  expect_false(fs::file_access(path, "write"))
+})
+
+
+test_that("files are writable when retrieved", {
+  obj <- file_store$new(withr::local_tempdir())
+
+  f <- withr::local_tempfile()
+  writeLines("Hello", f)
+  h <- hash_file(f)
+  obj$put(f, h)
+
+  path <- withr::local_tempfile()
+  obj$get(h, path, TRUE)
+  expect_true(fs::file_access(path, "read"))
+  expect_true(fs::file_access(path, "write"))
+  writeLines("World", path)
+})

--- a/tests/testthat/test-outpack-store.R
+++ b/tests/testthat/test-outpack-store.R
@@ -34,9 +34,9 @@ test_that("Can store files", {
   expect_length(obj$list(), 10)
   expect_equal(file.exists(obj$filename(obj$list())),
                rep(TRUE, 10))
-  dest <- temp_file()
-  dir.create(dest)
-  obj$get(obj$list(), dest, TRUE)
+
+  dest <- withr::local_tempdir()
+  obj$get(obj$list(), file.path(dest, letters[1:10]), FALSE)
 })
 
 

--- a/tests/testthat/test-util.R
+++ b/tests/testthat/test-util.R
@@ -497,7 +497,10 @@ describe("copy_files", {
   it("can copy zero files", {
     expect_no_error(copy_files(character(0), character(0)))
     expect_no_error(copy_files(character(0), character(0), overwrite = TRUE))
-    expect_no_error(copy_files(character(0), character(0), make_writable = TRUE))
+    expect_no_error(copy_files(character(0), character(0),
+                               make_writable = TRUE))
+    expect_no_error(copy_files(character(0), character(0),
+                               overwrite = TRUE, make_writable = TRUE))
   })
 
 
@@ -524,8 +527,8 @@ describe("copy_files", {
     copy_files(src, dst[[3]], make_writable = TRUE)
     copy_files(src, dst[[4]], make_writable = TRUE, overwrite = TRUE)
 
-    expect_true(all(fs::file_access(dst, mode="read")))
-    expect_equal(unname(fs::file_access(dst, mode="write")),
+    expect_true(all(fs::file_access(dst, mode = "read")))
+    expect_equal(unname(fs::file_access(dst, mode = "write")),
                  c(FALSE, FALSE, TRUE, TRUE))
   })
 


### PR DESCRIPTION
It has more bells and whistles, and is often more performant. In particular, it makes use of `CopyFileW` (on Windows) and `copy_file_range` (on Linux) when applicable. This offers a big speedup when copying a file within a network drive, which is a common use case for orderly.

The reason why `file.copy` was introduced in #165 is that copying read-only files with the `fs` package wasn't working properly on Samba drives. It turns out this situation only occurs when `overwrite = TRUE`. When the flag is set to FALSE, the copy succeeds. To work around this we do an initial check before the copy to delete any files in the destination path, and copy with `overwrite = FALSE`. This was manually tested by running the test suite with the `TMPDIR` environment variable set to a path on a network drive.