### PR TITLE
Refactor directory expansion.

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: orderly2
 Title: Orderly Next Generation
-Version: 1.99.36
+Version: 1.99.37
 Authors@R: c(person("Rich", "FitzJohn", role = c("aut", "cre"),
                     email = "rich.fitzjohn@gmail.com"),
              person("Robert", "Ashton", role = "aut"),

--- a/R/metadata.R
+++ b/R/metadata.R
@@ -391,28 +391,14 @@ copy_shared_resource <- function(path_root, path_dest, config, files, call) {
       shared_dir))
   }
 
-  here <- files$here
-  there <- files$there
-
-  assert_file_exists_relative(there, workdir = shared_path,
+  assert_file_exists_relative(files$there, workdir = shared_path,
                               name = "Shared resource file", call = call)
-  src <- file.path(shared_path, there)
-  dst <- file.path(path_dest, here)
 
-  is_dir <- is_directory(file.path(shared_path, there))
-  fs::dir_create(file.path(path_dest, dirname(here)))
-  if (any(is_dir)) {
-    fs::dir_copy(src[is_dir], dst[is_dir])
-    ## Update the names that will be used in the metadata:
-    files <- lapply(src[is_dir], dir)
-    here <- replace_ragged(here, is_dir, Map(file.path, here[is_dir], files))
-    there <- replace_ragged(there, is_dir, Map(file.path, there[is_dir], files))
-  }
-  if (any(!is_dir)) {
-    copy_files(src[!is_dir], dst[!is_dir], overwrite = TRUE)
-  }
-
-  data_frame(here = here, there = there)
+  files_expanded <- expand_dirs(files, shared_path)
+  copy_files(fs::path(shared_path, files_expanded$there),
+             fs::path(path_dest, files_expanded$here),
+             overwrite = TRUE)
+  files_expanded
 }
 
 

--- a/tests/testthat/test-outpack-packet.R
+++ b/tests/testthat/test-outpack-packet.R
@@ -583,7 +583,7 @@ test_that("can depend based on a simple query", {
     p$depends[[1]],
     list(packet = id$b[[3]],
          query = "latest()",
-         files = data.frame(there = "data.rds", here = "1.rds")))
+         files = data.frame(here = "1.rds", there = "data.rds")))
 
   query <- orderly_query("latest(parameter:i < 3)", name = "a")
   outpack_packet_use_dependency(p, query, c("2.rds" = "data.rds"))
@@ -591,7 +591,7 @@ test_that("can depend based on a simple query", {
     p$depends[[2]],
     list(packet = id$a[[2]],
          query = 'latest(parameter:i < 3 && name == "a")',
-         files = data.frame(there = "data.rds", here = "2.rds")))
+         files = data.frame(here = "2.rds", there = "data.rds")))
 })
 
 
@@ -790,8 +790,8 @@ test_that("can pull in directories", {
   p2 <- outpack_packet_start_quietly(path_src2, "b", root = root)
   outpack_packet_use_dependency(p2, 'latest(name == "a")', c(d = "data/"))
   expect_equal(p2$depends[[1]]$files,
-               data_frame(there = file.path("data", letters[1:6]),
-                          here = file.path("d", letters[1:6])))
+               data_frame(here = file.path("d", letters[1:6]),
+                          there = file.path("data", letters[1:6])))
 })
 
 

--- a/tests/testthat/test-run.R
+++ b/tests/testthat/test-run.R
@@ -1347,7 +1347,7 @@ test_that("can read about dependencies", {
   r <- readRDS(file.path(path, "archive", "depends", id2, "depends.rds"))
   expect_equal(r$id, id1)
   expect_equal(r$name, "data")
-  expect_equal(r$files, data_frame(there = "data.rds", here = "input.rds"))
+  expect_equal(r$files, data_frame(here = "input.rds", there = "data.rds"))
 
   res <- withr::with_dir(
     path_src,


### PR DESCRIPTION
There were three separate implementations of directory expansion spread across the codebase, each accepting slightly different inputs. The one used by `orderly_resource` operated over a single vector of paths.  The one used by `orderly_shared_resource` operated over a dataframe of `there`/`here` columns. Finally the one used by `orderly_copy_files` used the packet metadata to enumerate files, instead of looking at the filesystem.

The three implementations are replaced by just one, which uses callbacks to determine which files are directories and to enumerate their contents. This enables it to be used either with real files on disk or off of a packet's metadata.