### PR TITLE
Add support for specifying Packit tokens directly.

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: orderly2
 Title: Orderly Next Generation
-Version: 1.99.39
+Version: 1.99.40
 Authors@R: c(person("Rich", "FitzJohn", role = c("aut", "cre"),
                     email = "rich.fitzjohn@gmail.com"),
              person("Robert", "Ashton", role = "aut"),

--- a/R/location_packit.R
+++ b/R/location_packit.R
@@ -43,6 +43,12 @@ do_oauth_device_flow <- function(base_url, cache_disk) {
 # server from within the same session.
 auth_cache <- new.env(parent = emptyenv())
 packit_authorisation <- function(base_url, token, save_token) {
+  # If a non-Github token is provided, we assume it is a native Packit token
+  # and use that directly.
+  if (!is.null(token) && !grepl('^gh._', token)) {
+    return(list("Authorization" = paste("Bearer", token)))
+  }
+
   key <- rlang::hash(list(base_url = base_url, token = token))
 
   if (is.null(auth_cache[[key]])) {

--- a/R/location_packit.R
+++ b/R/location_packit.R
@@ -45,7 +45,7 @@ auth_cache <- new.env(parent = emptyenv())
 packit_authorisation <- function(base_url, token, save_token) {
   # If a non-Github token is provided, we assume it is a native Packit token
   # and use that directly.
-  if (!is.null(token) && !grepl('^gh._', token)) {
+  if (!is.null(token) && !grepl("^gh._", token)) {
     return(list("Authorization" = paste("Bearer", token)))
   }
 


### PR DESCRIPTION
As part of experimenting with new authentication methods for Packit, it is useful to be able to provide Packit tokens directly to orderly2. Until now, orderly2 would only accept GitHub tokens, and would perform a request to exchange it for a Packit token.

Thankfully, GitHub tokens have a [well defined and documented prefix][ghblog], of the form `ghp_`, `gho_`, ... The underscore makes sure it so that it never could never be confused with a JWT. Thanks to this, the distinction between Packit and GitHub tokens is unambiguous.

Eventually we may want to implement some of these authentication methods in orderly2 itself, but it the meantime this makes experimentation easier.

[ghblog]: https://github.blog/engineering/platform-security/behind-githubs-new-authentication-token-formats/