### PR TITLE
Make pulling metadata more chatty

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: orderly2
 Title: Orderly Next Generation
-Version: 1.99.46
+Version: 1.99.47
 Authors@R: c(person("Rich", "FitzJohn", role = c("aut", "cre"),
                     email = "rich.fitzjohn@gmail.com"),
              person("Robert", "Ashton", role = "aut"),

--- a/R/location.R
+++ b/R/location.R
@@ -280,39 +280,29 @@ orderly_location_list <- function(verbose = FALSE, root = NULL) {
 ##'   locations are always up to date and pulling metadata from them
 ##'   does nothing.
 ##'
-##' @param quiet Logical, indicating if we should print information
-##'   about locations searched and metadata found.  If not given, we
-##'   use the option of `orderly.quiet`, defaulting to `TRUE`.
-##'
 ##' @inheritParams orderly_metadata
 ##'
 ##' @return Nothing
 ##'
 ##' @export
-orderly_location_pull_metadata <- function(location = NULL, quiet = NULL,
-                                           root = NULL) {
+orderly_location_pull_metadata <- function(location = NULL, root = NULL) {
   root <- root_open(root, require_orderly = FALSE)
   location_name <- location_resolve_valid(location, root,
                                           include_local = FALSE,
                                           include_orphan = FALSE,
                                           allow_no_locations = TRUE,
                                           environment())
-  quiet <- orderly_quiet(quiet)
-  if (!quiet) {
-    cli::cli_alert_info(paste(
-      "Fetching metadata from {length(location_name)} location{?s}:",
-      "{squote({location_name})}"))
-  }
+  cli_alert_info(paste(
+    "Fetching metadata from {length(location_name)} location{?s}:",
+    "{squote({location_name})}"))
   for (name in location_name) {
     res <- location_pull_metadata(name, root)
-    if (!quiet) {
-      if (res$total > 0) {
-        cli::cli_alert_success(paste(
-          "Found {res$total} packet{?s} at '{name}', of which",
-          "{res$new} {?is/are} new"))
-      } else {
-        cli::cli_alert_warning("No metadata found at '{name}'")
-      }
+    if (res$total > 0) {
+      cli_alert_success(paste(
+        "Found {res$total} packet{?s} at '{name}', of which",
+        "{res$new} {?is/are} new"))
+    } else {
+      cli_alert_warning("No metadata found at '{name}'")
     }
   }
 

--- a/R/outpack_index.R
+++ b/R/outpack_index.R
@@ -57,7 +57,7 @@ outpack_index <- R6::R6Class(
 
 
 index_update <- function(root_path, prev, skip_cache, progress) {
-  progress <- progress %||% getOption("orderly_index_progress", TRUE)
+  progress <- progress %||% getOption("orderly.index_progress", TRUE)
   path_index <- file.path(root_path, ".outpack", "index", "outpack.rds")
 
   if (length(prev) == 0 && file.exists(path_index) && !skip_cache) {

--- a/R/query_index.R
+++ b/R/query_index.R
@@ -87,7 +87,7 @@ new_query_index <- function(root, options) {
   root <- root_open(root, require_orderly = FALSE)
 
   if (options$pull_metadata) {
-    orderly_location_pull_metadata(options$location, root)
+    orderly_location_pull_metadata(options$location, root = root)
   }
   idx <- root$index$data()
   metadata <- idx$metadata

--- a/R/util.R
+++ b/R/util.R
@@ -714,3 +714,12 @@ fill_missing_names <- function(x) {
   }
   x
 }
+
+
+orderly_quiet <- function(quiet, call = parent.frame()) {
+  if (is.null(quiet)) {
+    getOption("orderly.quiet", FALSE)
+  } else {
+    assert_scalar_logical(quiet, call = call)
+  }
+}

--- a/R/util.R
+++ b/R/util.R
@@ -705,6 +705,25 @@ is_testing <- function() {
   identical(Sys.getenv("TESTTHAT"), "true")
 }
 
+
+cli_alert_success <- function(..., .envir = parent.frame()) {
+  if (!orderly_quiet()) {
+    cli::cli_alert_success(..., .envir = .envir)
+  }
+}
+
+cli_alert_info <- function(..., .envir = parent.frame()) {
+  if (!orderly_quiet()) {
+    cli::cli_alert_info(..., .envir = .envir)
+  }
+}
+
+cli_alert_warning <- function(..., .envir = parent.frame()) {
+  if (!orderly_quiet()) {
+    cli::cli_alert_warning(..., .envir = .envir)
+  }
+}
+
 # Given a character vector, missing names are filled using the value.
 fill_missing_names <- function(x) {
   if (is.null(names(x))) {
@@ -716,10 +735,6 @@ fill_missing_names <- function(x) {
 }
 
 
-orderly_quiet <- function(quiet, call = parent.frame()) {
-  if (is.null(quiet)) {
-    getOption("orderly.quiet", FALSE)
-  } else {
-    assert_scalar_logical(quiet, call = call)
-  }
+orderly_quiet <- function() {
+  getOption("orderly.quiet", is_testing())
 }

--- a/man/orderly_location_pull_metadata.Rd
+++ b/man/orderly_location_pull_metadata.Rd
@@ -4,7 +4,7 @@
 \alias{orderly_location_pull_metadata}
 \title{Pull metadata from a location}
 \usage{
-orderly_location_pull_metadata(location = NULL, quiet = NULL, root = NULL)
+orderly_location_pull_metadata(location = NULL, root = NULL)
 }
 \arguments{
 \item{location}{The name of a location to pull from (see
@@ -12,10 +12,6 @@ orderly_location_pull_metadata(location = NULL, quiet = NULL, root = NULL)
 given, pulls from all locations.  The "local" and "orphan"
 locations are always up to date and pulling metadata from them
 does nothing.}
-
-\item{quiet}{Logical, indicating if we should print information
-about locations searched and metadata found.  If not given, we
-use the option of \code{orderly.quiet}, defaulting to \code{TRUE}.}
 
 \item{root}{The path to the root directory, or \code{NULL} (the
 default) to search for one from the current working

--- a/man/orderly_location_pull_metadata.Rd
+++ b/man/orderly_location_pull_metadata.Rd
@@ -4,7 +4,7 @@
 \alias{orderly_location_pull_metadata}
 \title{Pull metadata from a location}
 \usage{
-orderly_location_pull_metadata(location = NULL, root = NULL)
+orderly_location_pull_metadata(location = NULL, quiet = NULL, root = NULL)
 }
 \arguments{
 \item{location}{The name of a location to pull from (see
@@ -12,6 +12,10 @@ orderly_location_pull_metadata(location = NULL, root = NULL)
 given, pulls from all locations.  The "local" and "orphan"
 locations are always up to date and pulling metadata from them
 does nothing.}
+
+\item{quiet}{Logical, indicating if we should print information
+about locations searched and metadata found.  If not given, we
+use the option of \code{orderly.quiet}, defaulting to \code{TRUE}.}
 
 \item{root}{The path to the root directory, or \code{NULL} (the
 default) to search for one from the current working

--- a/tests/testthat/helper-orderly.R
+++ b/tests/testthat/helper-orderly.R
@@ -1,7 +1,8 @@
 options(outpack.schema_validate =
           requireNamespace("jsonvalidate", quietly = TRUE) &&
           packageVersion("jsonvalidate") >= "1.4.0",
-        orderly_index_progress = FALSE)
+        orderly_index_progress = FALSE,
+        orderly.quiet = TRUE)
 
 
 test_prepare_orderly_example <- function(examples, ...) {

--- a/tests/testthat/helper-orderly.R
+++ b/tests/testthat/helper-orderly.R
@@ -1,8 +1,7 @@
 options(outpack.schema_validate =
           requireNamespace("jsonvalidate", quietly = TRUE) &&
           packageVersion("jsonvalidate") >= "1.4.0",
-        orderly.index_progress = FALSE,
-        orderly.quiet = TRUE)
+        orderly.index_progress = FALSE)
 
 
 test_prepare_orderly_example <- function(examples, ...) {

--- a/tests/testthat/helper-orderly.R
+++ b/tests/testthat/helper-orderly.R
@@ -1,7 +1,7 @@
 options(outpack.schema_validate =
           requireNamespace("jsonvalidate", quietly = TRUE) &&
           packageVersion("jsonvalidate") >= "1.4.0",
-        orderly_index_progress = FALSE,
+        orderly.index_progress = FALSE,
         orderly.quiet = TRUE)
 
 


### PR DESCRIPTION
This PR makes pulling metadata a bit more chatty, which removes the feeling that it has done nothing when pulling from path locations; if I find that alarming I imagine that users will too.  I toyed with cli's "simple progress bar" api but instead just went with printing a few messages, which feels reasonable.

After our discussion about having to suppress the output of this everywhere, I have taken the liberty of adding an option `orderly.quiet` which I have set in the tests and put this behind.  We use this pattern elsewhere at least, for example: https://mrc-ide.github.io/hipercow/articles/details.html#hipercow-progress - this means that the fallout in the tests is minimal and I think the extra logic not that bad to think about.

Somehow in two package options we were already inconsistent so I've updated `orderly_index_progress` to `orderly.index_progress`