### PR TITLE
Allow envvar 'ORDERLY_ROOT' to use alternative root by default

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: orderly2
 Title: Orderly Next Generation
-Version: 1.99.44
+Version: 1.99.45
 Authors@R: c(person("Rich", "FitzJohn", role = c("aut", "cre"),
                     email = "rich.fitzjohn@gmail.com"),
              person("Robert", "Ashton", role = "aut"),

--- a/R/root.R
+++ b/R/root.R
@@ -147,7 +147,10 @@ root_open <- function(path, require_orderly, call = parent.frame()) {
     ## This is going to error, but the error later will do.
     path <- path$path
   }
-  locate <- is.null(path)
+
+  path <- path %||% Sys.getenv("ORDERLY_ROOT", NA_character_)
+
+  locate <- is.na(path)
   if (locate) {
     path <- getwd()
     path_outpack <- find_file_descend(".outpack", path)

--- a/R/root.R
+++ b/R/root.R
@@ -225,7 +225,7 @@ orderly_src_root <- function(path, locate = TRUE, call = parent.frame()) {
     locate <- FALSE
   }
   if (is.null(path)) {
-    path <- getwd()
+    path <- Sys.getenv("ORDERLY_ROOT", getwd())
   }
   assert_scalar_character(path)
   assert_is_directory(path)

--- a/tests/testthat/test-root.R
+++ b/tests/testthat/test-root.R
@@ -156,3 +156,27 @@ test_that("can identify a plain source root from a full root", {
   expect_equal(orderly_src_root(root$path, FALSE), root$path)
   expect_equal(orderly_src_root(root, FALSE), root$path)
 })
+
+
+test_that("can use ORDERLY_ROOT to control the working directory", {
+  a <- create_temporary_root()
+  b <- create_temporary_root()
+  c <- create_temporary_root()
+  path_a <- normalise_path(a$path)
+  path_b <- normalise_path(b$path)
+  path_c <- normalise_path(b$path)
+
+  withr::with_envvar(c(ORDERLY_ROOT = NA_character_), {
+    withr::with_dir(path_a, {
+      expect_equal(root_open(NULL)$path, path_a)
+      expect_equal(root_open(path_b)$path, path_b)
+    })
+  })
+
+  withr::with_envvar(c(ORDERLY_ROOT = path_c), {
+    withr::with_dir(path_a, {
+      expect_equal(root_open(NULL)$path, path_c)
+      expect_equal(root_open(path_b)$path, path_b)
+    })
+  })
+})

--- a/vignettes/collaboration.Rmd
+++ b/vignettes/collaboration.Rmd
@@ -127,7 +127,12 @@ orderly2::orderly_list_src()
 Alice needs to run `orderly::orderly_init()` first:
 
 ```{r, as = "alice", orderly_root = path_alice}
-orderly2::orderly_init(".")
+orderly2::orderly_init(path_alice)
+```
+
+after which Alice can use orderly commands:
+
+```{r, orderly_root = path_alice}
 orderly2::orderly_list_src()
 ```
 
@@ -154,8 +159,8 @@ orderly2::orderly_location_push(id, "server")
 
 Now, consider Bob. He also needs the source code cloned, orderly initialised, and the server added:
 
-```{r, as = "bob", orderly_root = path_bob}
-orderly2::orderly_init(".")
+```{r, as = "bob"}
+orderly2::orderly_init(path_bob)
 ```
 ```{r, include = FALSE, orderly_root = path_bob}
 orderly2::orderly_location_add_path("server", path = path_server)

--- a/vignettes/collaboration.Rmd
+++ b/vignettes/collaboration.Rmd
@@ -114,8 +114,8 @@ Both Alice and Bob clone this repo onto their machines, using their favourite gi
 
 At the moment, including hidden files (except `.git`), Alice sees:
 
-```{r, as = "alice", orderly_root = path_alice}
-fs::dir_tree(".", all = TRUE, glob = ".git", invert = TRUE)
+```{r, as = "alice"}
+fs::dir_tree(path_alice, all = TRUE, glob = ".git", invert = TRUE)
 ```
 
 At this point, after cloning Alice does not have the `.outpack` directory (see below)
@@ -126,7 +126,7 @@ orderly2::orderly_list_src()
 
 Alice needs to run `orderly::orderly_init()` first:
 
-```{r, as = "alice", orderly_root = path_alice}
+```{r, as = "alice}
 orderly2::orderly_init(path_alice)
 ```
 

--- a/vignettes/collaboration.Rmd
+++ b/vignettes/collaboration.Rmd
@@ -126,7 +126,7 @@ orderly2::orderly_list_src()
 
 Alice needs to run `orderly::orderly_init()` first:
 
-```{r, as = "alice}
+```{r, as = "alice"}
 orderly2::orderly_init(path_alice)
 ```
 

--- a/vignettes/collaboration.Rmd
+++ b/vignettes/collaboration.Rmd
@@ -114,26 +114,26 @@ Both Alice and Bob clone this repo onto their machines, using their favourite gi
 
 At the moment, including hidden files (except `.git`), Alice sees:
 
-```{r, as = "alice", inwd = path_alice}
+```{r, as = "alice", orderly_root = path_alice}
 fs::dir_tree(".", all = TRUE, glob = ".git", invert = TRUE)
 ```
 
 At this point, after cloning Alice does not have the `.outpack` directory (see below)
 
-```{r, as = "alice", inwd = path_alice, error = TRUE}
+```{r, as = "alice", orderly_root = path_alice, error = TRUE}
 orderly2::orderly_list_src()
 ```
 
 Alice needs to run `orderly::orderly_init()` first:
 
-```{r, as = "alice", inwd = path_alice}
+```{r, as = "alice", orderly_root = path_alice}
 orderly2::orderly_init(".")
 orderly2::orderly_list_src()
 ```
 
 The plan is to work with Bob, sharing results on their shared "[Packit](https://github.com/mrc-ide/packit)" server, so Alice adds that to her `orderly2` configuration with `orderly2::orderly_location_add_packit()`:
 
-```{r, include = FALSE, inwd = path_alice}
+```{r, include = FALSE, orderly_root = path_alice}
 orderly2::orderly_location_add_path("server", path = path_server)
 ```
 ```{r, eval = FALSE, as = "alice"}
@@ -142,22 +142,22 @@ orderly2::orderly_location_add_packit("server", "http://packit.example.com")
 
 Once done, she can run any analysis:
 
-```{r, as = "alice", inwd = path_alice}
+```{r, as = "alice", orderly_root = path_alice}
 id <- orderly2::orderly_run("data")
 ```
 
 Perhaps it takes several goes for Alice to be happy with the analysis, but at some point she has something ready to share. She can then "push" the final packet up onto their server:
 
-```{r, as = "alice", inwd = path_alice}
+```{r, as = "alice", orderly_root = path_alice}
 orderly2::orderly_location_push(id, "server")
 ```
 
 Now, consider Bob. He also needs the source code cloned, orderly initialised, and the server added:
 
-```{r, as = "bob", inwd = path_bob}
+```{r, as = "bob", orderly_root = path_bob}
 orderly2::orderly_init(".")
 ```
-```{r, include = FALSE, inwd = path_bob}
+```{r, include = FALSE, orderly_root = path_bob}
 orderly2::orderly_location_add_path("server", path = path_server)
 ```
 ```{r, eval = FALSE, as = "bob"}
@@ -168,7 +168,7 @@ orderly2::orderly_location_add_packit("server", "http://packit.example.com")
 
 Bob can now query for packets available on the server:
 
-```{r, as = "bob", inwd = path_bob}
+```{r, as = "bob", orderly_root = path_bob}
 orderly2::orderly_metadata_extract(
   name = "data",
   options = list(allow_remote = TRUE, pull_metadata = TRUE))
@@ -176,7 +176,7 @@ orderly2::orderly_metadata_extract(
 
 Having seen there is a new "data" packet here, he can pull this down locally (TODO: mrc-4414 makes this nicer):
 
-```{r, as = "bob", inwd = path_bob}
+```{r, as = "bob", orderly_root = path_bob}
 orderly2::orderly_location_pull_packet(id)
 ```
 
@@ -258,12 +258,12 @@ orderly2::orderly_init(
 
    Create an orderly store with a file store and a complete tree. See `orderly2::orderly_init()` for more details.
 1. Add this as a location
-    ```{r, as="alice", inwd = path_alice}
+    ```{r, as="alice", orderly_root = path_alice}
 orderly2::orderly_location_add_path("sharepoint", path = path_sharepoint_alice)
     ```
 
 1. Push any packets you want to share
-    ```{r, as="alice", inwd = path_alice}
+    ```{r, as="alice", orderly_root = path_alice}
 orderly2::orderly_location_push(id, "sharepoint")
     ```
 
@@ -271,11 +271,11 @@ Then these will be available for your collaborator to pull. Note that the data i
 
 1. Sync the same drive to a location on their machine. Here Bob has synced to `path_sharepoint_bob`
 1. Add the location
-    ```{r, as="bob", inwd = path_bob}
+    ```{r, as="bob", orderly_root = path_bob}
 orderly2::orderly_location_add_path("alices_orderly", path_sharepoint_bob)
     ```
 
 1. Pull the metadata and use the packets as desired
-    ```{r, as="bob", inwd = path_bob}
+    ```{r, as="bob", orderly_root = path_bob}
 orderly2::orderly_location_pull_metadata("alices_orderly")
     ```

--- a/vignettes/common.R
+++ b/vignettes/common.R
@@ -38,13 +38,11 @@ inline <- function(x) {
 knitr::opts_chunk$set(
   collapse = TRUE)
 
-.here <- getwd()
-knitr::knit_hooks$set(inwd = function(before, options) {
+knitr::knit_hooks$set(orderly_root = function(before, options) {
   if (before) {
-    setwd(options$inwd)
+    Sys.setenv(ORDERLY_ROOT = options$orderly_root)
   } else {
-    setwd(.here)
+    Sys.unsetenv("ORDERLY_ROOT")
   }
   invisible()
-}
-)
+})

--- a/vignettes/dependencies.Rmd
+++ b/vignettes/dependencies.Rmd
@@ -68,14 +68,14 @@ r_output(readLines(file.path(path, "src/analysis/analysis.R")))
 
 Here, we've used `orderly2::orderly_dependency()` to pull in the file `data.rds` from the most recent version (`latest()`) of the `data` packet, then we've used that file as normal to make a plot, which we've saved as `analysis.png` (this is very similar to the example from `vignette("introduction")`, to get us started).
 
-```{r, inwd = path}
+```{r, orderly_root = path}
 id1 <- orderly2::orderly_run("data")
 id2 <- orderly2::orderly_run("analysis")
 ```
 
 When we look at the metadata for the packet created from the `analysis` report, we can see it has used `r inline(id1)` as its dependency:
 
-```{r, inwd = path}
+```{r, orderly_root = path}
 orderly2::orderly_metadata(id2)$depends
 ```
 
@@ -122,7 +122,7 @@ r_output(readLines(file.path(path, "src/data/data.R")))
 
 We can run this for several values of `cyl`:
 
-```{r, inwd = path}
+```{r, orderly_root = path}
 orderly2::orderly_run("data", list(cyl = 4))
 orderly2::orderly_run("data", list(cyl = 6))
 orderly2::orderly_run("data", list(cyl = 8))
@@ -136,7 +136,7 @@ r_output(readLines(file.path(path, "src/analysis/analysis.R")))
 
 Here the query `latest(parameter:cyl == this:cyl)` says "find the most recent packet where it's parameter "cyl" (`parameter:cyl`) is the same as the parameter in the currently running report (`this:cyl`).
 
-```{r, inwd = path}
+```{r, orderly_root = path}
 orderly2::orderly_run("analysis", list(cyl = 4))
 ```
 
@@ -144,7 +144,7 @@ orderly2::orderly_run("analysis", list(cyl = 4))
 
 If your query fails to resolve a candidate it will error:
 
-```{r, error = TRUE, inwd = path}
+```{r, error = TRUE, orderly_root = path, purl = FALSE}
 orderly2::orderly_run("analysis", list(cyl = 9000))
 ```
 
@@ -162,14 +162,14 @@ This tells you that your query can be decomposed into two subqueries `A` (the ma
 
 You can also ask `orderly2` to explain any query for you:
 
-```{r, inwd = path}
+```{r, orderly_root = path}
 orderly2::orderly_query_explain(
   quote(latest(parameter:cyl == 9000)), name = "data")
 ```
 
 If you save this object you can explore it in more detail:
 
-```{r, inwd = path}
+```{r, orderly_root = path}
 explanation <- orderly2::orderly_query_explain(
   quote(latest(parameter:cyl == 9000)), name = "data")
 explanation$parts$B
@@ -179,7 +179,7 @@ explanation$parts$B
 
 You can also use `orderly2::orderly_metadata_extract` to work out what values you might have looked for:
 
-```{r, inwd = path}
+```{r, orderly_root = path}
 orderly2::orderly_metadata_extract(
   name = "data",
   extract = c(cyl = "parameters.cyl is number"))

--- a/vignettes/introduction.Rmd
+++ b/vignettes/introduction.Rmd
@@ -95,7 +95,7 @@ r_output(readLines(file.path(path, "src/incoming_data/incoming_data.R")))
 
 To run the report and create a new **packet**, use `orderly2::orderly_run()`:
 
-```{r, inwd = path}
+```{r, orderly_root = path}
 id <- orderly2::orderly_run("incoming_data")
 id
 ```
@@ -122,7 +122,7 @@ That's it! Notice that the initial script is just a plain R script, and you can 
 
 Once created, you can then refer to this report by id and pull its files wherever you need them, both in the context of another orderly report or just to copy to your desktop to email someone. For example, to copy the file `data.rds` that we created to some location outside of orderly's control you could do
 
-```{r, inwd = path}
+```{r, orderly_root = path}
 dest <- tempfile()
 fs::dir_create(dest)
 orderly2::orderly_copy_files(id, files = c("final.rds" = "data.rds"),
@@ -164,7 +164,7 @@ Here, we've used `orderly2::orderly_dependency()` to pull in the file `data.rds`
 
 We can run this just as before, using `orderly2::orderly_run()`:
 
-```{r, inwd = path}
+```{r, orderly_root = path}
 id <- orderly2::orderly_run("analysis")
 ```
 
@@ -204,7 +204,7 @@ r_output(readLines(file.path(path, "src/incoming_data/incoming_data.R")))
 
 Here, we've added a block of special orderly commands; these could go anywhere, for example above the files that they refer to. If strict mode is enabled (see below) then `orderly2::orderly_resource` calls must go before the files are used as they will only be made available at that point (see below).
 
-```{r, inwd = path}
+```{r, orderly_root = path}
 id <- orderly2::orderly_run("incoming_data")
 ```
 
@@ -250,13 +250,13 @@ You can do anything in your report that switches on the value of a parameter:
 
 However, you should see parameters as relatively heavyweight things and try to have a consistent set over all packets created from a report. In this report we use it to control the size of the generated data set.
 
-```{r, inwd = path}
+```{r, orderly_root = path}
 id <- orderly2::orderly_run("random", list(n_samples = 15))
 ```
 
 Our resulting file has 15 rows, as the parameter we passed in affected the report:
 
-```{r, inwd = path}
+```{r, orderly_root = path}
 orderly2::orderly_copy_files(id, files = c("random.rds" = "data.rds"),
                              dest = dest)
 readRDS(file.path(dest, "random.rds"))
@@ -264,13 +264,13 @@ readRDS(file.path(dest, "random.rds"))
 
 You can use these parameters in orderly's search functions. For example we can find the most recent version of a packet by running:
 
-```{r, inwd = path}
+```{r, orderly_root = path}
 orderly2::orderly_search('latest(name == "random")')
 ```
 
 But we can also pass in parameter queries here:
 
-```{r, inwd = path}
+```{r, orderly_root = path}
 orderly2::orderly_search('latest(name == "random" && parameter:n_samples > 10)')
 ```
 
@@ -325,7 +325,7 @@ r_output(readLines(file.path(path, "src/use_shared/use_shared.R")))
 
 We can run this:
 
-```{r, inwd = path}
+```{r, orderly_root = path}
 id <- orderly2::orderly_run("use_shared")
 ```
 
@@ -365,7 +365,7 @@ withr::with_dir(file.path(path, "src/incoming_data"),
                 sys.source("incoming_data.R", new.env(parent = .GlobalEnv)))
 ```
 
-```{r, inwd = path}
+```{r, orderly_root = path}
 orderly2::orderly_cleanup_status("incoming_data")
 ```
 
@@ -373,7 +373,7 @@ If you have files here that are unknown to orderly it will tell you about them a
 
 You can clean up generated files by running (as suggested in the message):
 
-```{r, inwd = path}
+```{r, orderly_root = path}
 orderly2::orderly_cleanup("incoming_data")
 ```
 
@@ -381,7 +381,7 @@ There is a `dry_run = TRUE` argument you can pass if you want to see what would 
 
 You can also keep these files out of git by using the `orderly2::orderly_gitignore_update` function:
 
-```{r, inwd = path}
+```{r, orderly_root = path}
 orderly2::orderly_gitignore_update("incoming_data")
 ```
 
@@ -393,20 +393,20 @@ If you delete packets from your `archive/` directory then this puts `orderly2` i
 
 At the moment, we have two copies of the `incoming_data` task:
 
-```{r, inwd = path}
+```{r, orderly_root = path}
 orderly2::orderly_metadata_extract(
   name = "incoming_data",
   extract = c(time = "time.start"))
 ```
 
-```{r include = FALSE, inwd = path}
+```{r include = FALSE, orderly_root = path}
 id_latest <- orderly2::orderly_search("latest", name = "incoming_data")
 fs::dir_delete(file.path(path, "archive", "incoming_data", id_latest))
 ```
 
 When we run the `analysis` task, it will pull in the most recent version (`r inline(id_latest)`). However, if you had deleted this manually (e.g., to save space or accidentally) or corrupted it (e.g., by opening some output in Excel and letting it save changes) it will not be able to be included, and running `analysis` will fail:
 
-```{r error = TRUE, inwd = path}
+```{r error = TRUE, orderly_root = path}
 orderly2::orderly_run("analysis")
 ```
 
@@ -422,7 +422,7 @@ r_output(
 
 or we can validate *all* the packets we have:
 
-```{r, inwd = path}
+```{r, orderly_root = path}
 orderly2::orderly_validate_archive(action = "orphan")
 ```
 
@@ -430,7 +430,7 @@ If we had the option `core.require_complete_tree` enabled, then this process wou
 
 If you want to remove references to the orphaned packets, you can use `orderly2::orderly_prune_orphans()` to remove them entirely:
 
-```{r, inwd = path}
+```{r, orderly_root = path}
 orderly2::orderly_prune_orphans()
 ```
 
@@ -475,7 +475,7 @@ As can be perhaps inferred from the filenames, the files `.outpack/metadata/<pac
 
 The default orderly configuration is to store the final files in a directory called `archive/`, but alternatively (or additionally) you can use a [content- addressable](https://en.wikipedia.org/wiki/Content-addressable_storage) file store. With this enabled, the `.outpack` directory looks like:
 
-```{r, echo = FALSE, inwd = path}
+```{r, echo = FALSE, orderly_root = path}
 orderly2::orderly_config_set(core.use_file_store = TRUE)
 dir_tree(path, ".outpack", all = TRUE)
 ```

--- a/vignettes/troubleshooting.Rmd
+++ b/vignettes/troubleshooting.Rmd
@@ -18,7 +18,7 @@ We have now put in guard rails to try and prevent this happening, but it could s
 Once you are in this situation, `orderly2` will shout at you:
 
 ```{r, include = FALSE}
-source("common.Rmd")
+source("common.R")
 path <- orderly2::orderly_example("default")
 orderly2::orderly_run("data", root = path)
 gert::git_init(path)

--- a/vignettes/troubleshooting.Rmd
+++ b/vignettes/troubleshooting.Rmd
@@ -18,25 +18,16 @@ We have now put in guard rails to try and prevent this happening, but it could s
 Once you are in this situation, `orderly2` will shout at you:
 
 ```{r, include = FALSE}
+source("common.Rmd")
 path <- orderly2::orderly_example("default")
 orderly2::orderly_run("data", root = path)
 gert::git_init(path)
 gert::git_add(".", repo = path)
 user <- "author <author@example.com>"
 gert::git_commit("initial", author = user, committer = user, repo = path)
-
-.here <- getwd()
-knitr::knit_hooks$set(inwd = function(before, options) {
-  if (before) {
-    setwd(options$inwd)
-  } else {
-    setwd(.here)
-  }
-  invisible()
-})
 ```
 
-```{r, error = TRUE, inwd = path}
+```{r, error = TRUE, orderly_root = path}
 orderly2::orderly_run("data")
 ```
 
@@ -48,13 +39,13 @@ options(orderly_git_error_is_warning = TRUE)
 
 after which things will work with a warning the first time that session:
 
-```{r, inwd = path}
+```{r, orderly_root = path}
 orderly2::orderly_run("data")
 ```
 
 subsequent calls will not display the warning:
 
-```{r, inwd = path}
+```{r, orderly_root = path}
 orderly2::orderly_run("data")
 ```
 


### PR DESCRIPTION
Add support for an environment variable `ORDERLY_ROOT` that we look up when `root` is not provided (i.e., is `NULL`).  This allows us to control the apparent root of orderly in documentation (see usage in the vignettes here), and appears more usable in quarto docs than the previous `setwd` hack, which is now removed.  This is not documented or advertised anywhere, but we can do do if we think it makes sense to allow users to work this way too.