### PR TITLE
Make example runner less clever

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: orderly2
 Title: Orderly Next Generation
-Version: 1.99.47
+Version: 1.99.48
 Authors@R: c(person("Rich", "FitzJohn", role = c("aut", "cre"),
                     email = "rich.fitzjohn@gmail.com"),
              person("Robert", "Ashton", role = "aut"),

--- a/R/cleanup.R
+++ b/R/cleanup.R
@@ -66,7 +66,7 @@
 ##' # Do the actual deletion:
 ##' orderly2::orderly_cleanup("data", root = path)
 ##'
-##' unlink(path, recursive = TRUE)
+##' fs::dir_delete(path, recursive = TRUE)
 orderly_cleanup <- function(name = NULL, dry_run = FALSE, root = NULL) {
   status <- orderly_cleanup_status(name, root)
   n <- length(status$delete)

--- a/R/cleanup.R
+++ b/R/cleanup.R
@@ -42,7 +42,6 @@
 ##'
 ##' @export
 ##' @examples
-##' message(sprintf("Running in %s", format(environment())))
 ##' # Create a simple example:
 ##' path <- orderly2::orderly_example("default")
 ##'

--- a/R/cleanup.R
+++ b/R/cleanup.R
@@ -66,7 +66,7 @@
 ##' # Do the actual deletion:
 ##' orderly2::orderly_cleanup("data", root = path)
 ##'
-##' fs::dir_delete(path, recursive = TRUE)
+##' fs::dir_delete(path)
 orderly_cleanup <- function(name = NULL, dry_run = FALSE, root = NULL) {
   status <- orderly_cleanup_status(name, root)
   n <- length(status$delete)

--- a/R/cleanup.R
+++ b/R/cleanup.R
@@ -7,11 +7,11 @@
 ##' directories; orderly2 has similar semantics here to git where
 ##' directories are never directly tracked.
 ##'
-##' For recent `gert` (not yet on CRAN) we will ask git if files are
-##' ignored; if ignored then they are good candidates for deletion! We
-##' encourage you to keep a per-report `.gitignore` that lists files
-##' that will copy into the source directory, and then we can use that
-##' same information to clean up these files after generation.
+##' For recent `gert` we will ask git if files are ignored; if ignored
+##' then they are good candidates for deletion! We encourage you to
+##' keep a per-report `.gitignore` that lists files that will copy
+##' into the source directory, and then we can use that same
+##' information to clean up these files after generation.
 ##' Importantly, even if a file matches an ignore rule but has been
 ##' committed to your repository, it will no longer match the ignore
 ##' rule.
@@ -42,6 +42,7 @@
 ##'
 ##' @export
 ##' @examples
+##' message(sprintf("Running in %s", format(environment())))
 ##' # Create a simple example:
 ##' path <- orderly2::orderly_example("default")
 ##'
@@ -65,6 +66,8 @@
 ##'
 ##' # Do the actual deletion:
 ##' orderly2::orderly_cleanup("data", root = path)
+##'
+##' unlink(path, recursive = TRUE)
 orderly_cleanup <- function(name = NULL, dry_run = FALSE, root = NULL) {
   status <- orderly_cleanup_status(name, root)
   n <- length(status$delete)

--- a/R/example.R
+++ b/R/example.R
@@ -20,7 +20,7 @@
 ##' path <- orderly2::orderly_example("default")
 ##' orderly2::orderly_list_src(root = path)
 ##'
-##' unlink(path, recursive = TRUE)
+##' fs::dir_delete(path, recursive = TRUE)
 orderly_example <- function(name, ..., dest = NULL) {
   match_value(name, "default", call = environment())
   if (is.null(dest)) {

--- a/R/example.R
+++ b/R/example.R
@@ -20,7 +20,7 @@
 ##' path <- orderly2::orderly_example("default")
 ##' orderly2::orderly_list_src(root = path)
 ##'
-##' fs::dir_delete(path, recursive = TRUE)
+##' fs::dir_delete(path)
 orderly_example <- function(name, ..., dest = NULL) {
   match_value(name, "default", call = environment())
   if (is.null(dest)) {

--- a/R/example.R
+++ b/R/example.R
@@ -19,18 +19,20 @@
 ##' @examples
 ##' path <- orderly2::orderly_example("default")
 ##' orderly2::orderly_list_src(root = path)
+##'
+##' unlink(path, recursive = TRUE)
 orderly_example <- function(name, ..., dest = NULL) {
   match_value(name, "default", call = environment())
   if (is.null(dest)) {
-    dest <- withr::local_tempfile(.local_envir = parent.frame())
+    dest <- tempfile("orderly2_ex_")
   } else {
-    assert_scalar_character(dest, call = environment())
+    assert_scalar_character(dest)
+    if (file.exists(dest)) {
+      cli::cli_abort("The path '{dest}' cannot exist")
+    }
   }
-  if (file.exists(dest)) {
-    cli::cli_abort("The path '{dest}' cannot exist")
-  }
+  orderly_init(..., root = dest)
   src <- orderly2_file("example")
-  fs::dir_copy(src, dest)
-  orderly2::orderly_init(..., root = dest)
+  fs::dir_copy(file.path(src, "src"), dest)
   invisible(dest)
 }

--- a/R/example.R
+++ b/R/example.R
@@ -28,7 +28,7 @@ orderly_example <- function(name, ..., dest = NULL) {
   } else {
     assert_scalar_character(dest)
     if (file.exists(dest)) {
-      cli::cli_abort("The path '{dest}' cannot exist")
+      cli::cli_abort("The path '{dest}' must not exist")
     }
   }
   orderly_init(..., root = dest)

--- a/R/orderly.R
+++ b/R/orderly.R
@@ -17,7 +17,7 @@
 ##' @examples
 ##' path <- orderly2::orderly_example("default")
 ##' orderly2::orderly_list_src(root = path)
-##' fs::dir_delete(path, recursive = TRUE)
+##' fs::dir_delete(path)
 orderly_list_src <- function(root = NULL) {
   root_path <- orderly_src_root(root)
   if (!file.exists(file.path(root_path, "src"))) {

--- a/R/orderly.R
+++ b/R/orderly.R
@@ -17,7 +17,7 @@
 ##' @examples
 ##' path <- orderly2::orderly_example("default")
 ##' orderly2::orderly_list_src(root = path)
-##' unlink(path, recursive = TRUE)
+##' fs::dir_delete(path, recursive = TRUE)
 orderly_list_src <- function(root = NULL) {
   root_path <- orderly_src_root(root)
   if (!file.exists(file.path(root_path, "src"))) {

--- a/R/orderly.R
+++ b/R/orderly.R
@@ -17,6 +17,7 @@
 ##' @examples
 ##' path <- orderly2::orderly_example("default")
 ##' orderly2::orderly_list_src(root = path)
+##' unlink(path, recursive = TRUE)
 orderly_list_src <- function(root = NULL) {
   root_path <- orderly_src_root(root)
   if (!file.exists(file.path(root_path, "src"))) {

--- a/R/run.R
+++ b/R/run.R
@@ -150,6 +150,9 @@
 ##'
 ##' # and we can query the metadata:
 ##' orderly2::orderly_metadata_extract(name = "data", root = path)
+##'
+##' # Cleanup
+##' unlink(path, recursive = TRUE)
 orderly_run <- function(name, parameters = NULL, envir = NULL, echo = TRUE,
                         location = NULL, allow_remote = NULL,
                         pull_metadata = FALSE, search_options = NULL,

--- a/R/run.R
+++ b/R/run.R
@@ -152,7 +152,7 @@
 ##' orderly2::orderly_metadata_extract(name = "data", root = path)
 ##'
 ##' # Cleanup
-##' fs::dir_delete(path, recursive = TRUE)
+##' fs::dir_delete(path)
 orderly_run <- function(name, parameters = NULL, envir = NULL, echo = TRUE,
                         location = NULL, allow_remote = NULL,
                         pull_metadata = FALSE, search_options = NULL,

--- a/R/run.R
+++ b/R/run.R
@@ -152,7 +152,7 @@
 ##' orderly2::orderly_metadata_extract(name = "data", root = path)
 ##'
 ##' # Cleanup
-##' unlink(path, recursive = TRUE)
+##' fs::dir_delete(path, recursive = TRUE)
 orderly_run <- function(name, parameters = NULL, envir = NULL, echo = TRUE,
                         location = NULL, allow_remote = NULL,
                         pull_metadata = FALSE, search_options = NULL,

--- a/man/orderly_cleanup.Rd
+++ b/man/orderly_cleanup.Rd
@@ -84,5 +84,5 @@ orderly2::orderly_cleanup_status("data", root = path)
 # Do the actual deletion:
 orderly2::orderly_cleanup("data", root = path)
 
-fs::dir_delete(path, recursive = TRUE)
+fs::dir_delete(path)
 }

--- a/man/orderly_cleanup.Rd
+++ b/man/orderly_cleanup.Rd
@@ -41,11 +41,11 @@ After file deletion, we look through and remove all empty
 directories; orderly2 has similar semantics here to git where
 directories are never directly tracked.
 
-For recent \code{gert} (not yet on CRAN) we will ask git if files are
-ignored; if ignored then they are good candidates for deletion! We
-encourage you to keep a per-report \code{.gitignore} that lists files
-that will copy into the source directory, and then we can use that
-same information to clean up these files after generation.
+For recent \code{gert} we will ask git if files are ignored; if ignored
+then they are good candidates for deletion! We encourage you to
+keep a per-report \code{.gitignore} that lists files that will copy
+into the source directory, and then we can use that same
+information to clean up these files after generation.
 Importantly, even if a file matches an ignore rule but has been
 committed to your repository, it will no longer match the ignore
 rule.
@@ -60,6 +60,7 @@ files then compare that with the directory.
 }
 
 \examples{
+message(sprintf("Running in \%s", format(environment())))
 # Create a simple example:
 path <- orderly2::orderly_example("default")
 
@@ -83,4 +84,6 @@ orderly2::orderly_cleanup_status("data", root = path)
 
 # Do the actual deletion:
 orderly2::orderly_cleanup("data", root = path)
+
+unlink(path, recursive = TRUE)
 }

--- a/man/orderly_cleanup.Rd
+++ b/man/orderly_cleanup.Rd
@@ -60,7 +60,6 @@ files then compare that with the directory.
 }
 
 \examples{
-message(sprintf("Running in \%s", format(environment())))
 # Create a simple example:
 path <- orderly2::orderly_example("default")
 

--- a/man/orderly_cleanup.Rd
+++ b/man/orderly_cleanup.Rd
@@ -84,5 +84,5 @@ orderly2::orderly_cleanup_status("data", root = path)
 # Do the actual deletion:
 orderly2::orderly_cleanup("data", root = path)
 
-unlink(path, recursive = TRUE)
+fs::dir_delete(path, recursive = TRUE)
 }

--- a/man/orderly_example.Rd
+++ b/man/orderly_example.Rd
@@ -29,5 +29,5 @@ should not form part of your workflow!
 path <- orderly2::orderly_example("default")
 orderly2::orderly_list_src(root = path)
 
-fs::dir_delete(path, recursive = TRUE)
+fs::dir_delete(path)
 }

--- a/man/orderly_example.Rd
+++ b/man/orderly_example.Rd
@@ -28,4 +28,6 @@ should not form part of your workflow!
 \examples{
 path <- orderly2::orderly_example("default")
 orderly2::orderly_list_src(root = path)
+
+unlink(path, recursive = TRUE)
 }

--- a/man/orderly_example.Rd
+++ b/man/orderly_example.Rd
@@ -29,5 +29,5 @@ should not form part of your workflow!
 path <- orderly2::orderly_example("default")
 orderly2::orderly_list_src(root = path)
 
-unlink(path, recursive = TRUE)
+fs::dir_delete(path, recursive = TRUE)
 }

--- a/man/orderly_list_src.Rd
+++ b/man/orderly_list_src.Rd
@@ -26,7 +26,7 @@ as the directory (e.g., \code{src/data/data.R} corresponds to \code{data}).
 \examples{
 path <- orderly2::orderly_example("default")
 orderly2::orderly_list_src(root = path)
-unlink(path, recursive = TRUE)
+fs::dir_delete(path, recursive = TRUE)
 }
 \seealso{
 \link{orderly_metadata_extract} for listing packets

--- a/man/orderly_list_src.Rd
+++ b/man/orderly_list_src.Rd
@@ -26,7 +26,7 @@ as the directory (e.g., \code{src/data/data.R} corresponds to \code{data}).
 \examples{
 path <- orderly2::orderly_example("default")
 orderly2::orderly_list_src(root = path)
-fs::dir_delete(path, recursive = TRUE)
+fs::dir_delete(path)
 }
 \seealso{
 \link{orderly_metadata_extract} for listing packets

--- a/man/orderly_list_src.Rd
+++ b/man/orderly_list_src.Rd
@@ -26,6 +26,7 @@ as the directory (e.g., \code{src/data/data.R} corresponds to \code{data}).
 \examples{
 path <- orderly2::orderly_example("default")
 orderly2::orderly_list_src(root = path)
+unlink(path, recursive = TRUE)
 }
 \seealso{
 \link{orderly_metadata_extract} for listing packets

--- a/man/orderly_run.Rd
+++ b/man/orderly_run.Rd
@@ -199,5 +199,5 @@ fs::dir_tree(path)
 orderly2::orderly_metadata_extract(name = "data", root = path)
 
 # Cleanup
-fs::dir_delete(path, recursive = TRUE)
+fs::dir_delete(path)
 }

--- a/man/orderly_run.Rd
+++ b/man/orderly_run.Rd
@@ -197,4 +197,7 @@ fs::dir_tree(path)
 
 # and we can query the metadata:
 orderly2::orderly_metadata_extract(name = "data", root = path)
+
+# Cleanup
+unlink(path, recursive = TRUE)
 }

--- a/man/orderly_run.Rd
+++ b/man/orderly_run.Rd
@@ -199,5 +199,5 @@ fs::dir_tree(path)
 orderly2::orderly_metadata_extract(name = "data", root = path)
 
 # Cleanup
-unlink(path, recursive = TRUE)
+fs::dir_delete(path, recursive = TRUE)
 }

--- a/tests/testthat/test-example.R
+++ b/tests/testthat/test-example.R
@@ -1,18 +1,3 @@
-test_that("can use self destructing paths", {
-  res <- local({
-    res <- local({
-      tmp <- withr::local_tempfile()
-      path <- suppressMessages(orderly_example("default", dest = NULL))
-      list(path = path, exists_inner = file.exists(path))
-    })
-    res$exists_outer <- file.exists(res$path)
-    res
-  })
-  expect_true(res$exists_inner)
-  expect_false(res$exists_outer)
-})
-
-
 test_that("can use custom path", {
   path <- withr::local_tempfile()
   res <- suppressMessages(orderly_example("default", dest = path))

--- a/tests/testthat/test-example.R
+++ b/tests/testthat/test-example.R
@@ -19,5 +19,5 @@ test_that("can set config", {
 test_that("error if path exists", {
   path <- withr::local_tempdir()
   expect_error(orderly_example("default", dest = path),
-               "The path '.+' cannot exist")
+               "The path '.+' must not exist")
 })


### PR DESCRIPTION
After a short fight, I can't get the withr deferred events to behave nicely under `devtools::run_examples`, which is I presume a similar environment to `pkgdown` - which leads to the silently failing examples on the docs.  I've updated this to be very simple now and not try and clean up automatically at all, which should mean that the docs now run with no problems.