### PR TITLE
Cope better with relative locations

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: orderly2
 Title: Orderly Next Generation
-Version: 1.99.49
+Version: 1.99.50
 Authors@R: c(person("Rich", "FitzJohn", role = c("aut", "cre"),
                     email = "rich.fitzjohn@gmail.com"),
              person("Robert", "Ashton", role = "aut"),

--- a/man/orderly_location_add.Rd
+++ b/man/orderly_location_add.Rd
@@ -43,9 +43,18 @@ directory. This function does not require that the directory is
 configured for orderly, and can be any \code{outpack} root (see
 \link{orderly_init} for details).}
 
-\item{path}{The path to the other archive root. This should
-generally be an absolute path, or the behaviour of outpack will
-be unreliable.}
+\item{path}{The path to the other archive root. This can be a
+relative or absolute path, with different tradeoffs.  If you use
+an absolute path, then this location will typically work well on
+this machine, but it may behave poorly when the location is
+found on a shared drive \strong{and} when you use your orderly root
+from more than one system.  This setup is common when using an
+HPC system.  If you use a relative path, then we will interpret
+it \strong{relative to your orderly root} and not the directory that
+you evaluate this command from.  Typically your path should
+include leading dots (e.g. \verb{../../somewhere/else}) as you should
+not nest orderly projects.  This approach should work fine on
+shared filesystems.}
 
 \item{url}{The location of the server, including protocol, for
 example \verb{http://example.com:8080}}

--- a/tests/testthat/test-location-path.R
+++ b/tests/testthat/test-location-path.R
@@ -396,6 +396,7 @@ test_that("allow weird absolute paths in path locations", {
 
 test_that("provide hint when wrong relative path given", {
   tmp <- withr::local_tempdir()
+  tmp <- normalizePath(tmp)
   nms <- letters[1:3]
   root <- suppressMessages(
     set_names(lapply(nms, function(x) orderly_init(file.path(tmp, x))), nms))

--- a/tests/testthat/test-location.R
+++ b/tests/testthat/test-location.R
@@ -850,7 +850,8 @@ test_that("can add a packit location", {
     list("packit",
          list(url = "https://example.com",
               token = "abc123",
-              save_token = FALSE)))
+              save_token = FALSE),
+         root))
 })
 
 test_that("can add a packit location without a token", {
@@ -873,7 +874,8 @@ test_that("can add a packit location without a token", {
   expect_equal(
     mockery::mock_args(mock_driver)[[1]],
     list("packit",
-         list(url = "https://example.com", token = NULL, save_token = TRUE)))
+         list(url = "https://example.com", token = NULL, save_token = TRUE),
+         root))
 })
 
 test_that("cope with trailing slash in url if needed", {
@@ -947,7 +949,7 @@ test_that("can add a custom outpack location", {
   expect_equal(location_driver(loc$name, root), "value")
   mockery::expect_called(mock_orderly_location_driver_create, 1)
   expect_equal(mockery::mock_args(mock_orderly_location_driver_create)[[1]],
-               list("custom", list(driver = "foo::bar", a = 1, b = 2)))
+               list("custom", list(driver = "foo::bar", a = 1, b = 2), root))
 })
 
 


### PR DESCRIPTION
Previously we allowed relative paths to be used for locations but it was ambiguous where they were looked up.  This is a problem in contexts where absolute paths are not suitable (e.g., on the cluster where the mount point on the nodes is different to the submitting workstation).

This PR removes the ambiguity - we take the path relative to the root, and **not** relative to the command that calls `orderly_location_add_path()`.  This might be confusing so there's a special case error that we throw if it looks like the wrong relative path was chosen.

When we load the driver we change back to the root and then interpret the path at that point.  This is also done when the user verifies addition (in #188).