### PR TITLE
Gh 143

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: orderly2
 Title: Orderly Next Generation
-Version: 1.99.50
+Version: 1.99.51
 Authors@R: c(person("Rich", "FitzJohn", role = c("aut", "cre"),
                     email = "rich.fitzjohn@gmail.com"),
              person("Robert", "Ashton", role = "aut"),

--- a/R/location.R
+++ b/R/location.R
@@ -556,7 +556,7 @@ location_push_files <- function(files, driver, root) {
             i = paste("The original file has been changed or deleted.",
                       "Details are above")))
       }
-      size <- as.character(fs::file_size(src))
+      size <- pretty_bytes(fs::file_size(src))
       cli_progress_update()
       driver$push_file(src, hash)
     }

--- a/R/location.R
+++ b/R/location.R
@@ -525,6 +525,7 @@ orderly_location_push <- function(expr, location, name = NULL, dry_run = FALSE,
       driver <- location_driver(location_name, root)
       location_push_files(plan$files, driver, root)
       location_push_metadata(plan$packet_id, driver, root)
+      orderly_location_pull_metadata(location_name, root)
     }
   }
 

--- a/R/util.R
+++ b/R/util.R
@@ -724,6 +724,21 @@ cli_alert_warning <- function(..., .envir = parent.frame()) {
   }
 }
 
+cli_progress_bar <- function(..., .envir = parent.frame(), immediate = TRUE) {
+  if (immediate) {
+    withr::local_options(cli.progress_show_after = 0, .local_envir = .envir)
+  }
+  if (!orderly_quiet()) {
+    cli::cli_progress_bar(..., .envir = .envir)
+  }
+}
+
+cli_progress_update <- function(..., .envir = parent.frame()) {
+  if (!orderly_quiet()) {
+    cli::cli_progress_update(..., .envir = .envir)
+  }
+}
+
 # Given a character vector, missing names are filled using the value.
 fill_missing_names <- function(x) {
   if (is.null(names(x))) {

--- a/man/orderly_location_push.Rd
+++ b/man/orderly_location_push.Rd
@@ -4,13 +4,27 @@
 \alias{orderly_location_push}
 \title{Push tree to location}
 \usage{
-orderly_location_push(packet_id, location, root = NULL)
+orderly_location_push(
+  expr,
+  location,
+  name = NULL,
+  dry_run = FALSE,
+  root = NULL
+)
 }
 \arguments{
-\item{packet_id}{One or more packets to push to the server}
+\item{expr}{An expression to search for.  Often this will be a
+vector of ids, but you can use a query here.}
 
 \item{location}{The name of a location to push to (see
 \link{orderly_location_list} for possible values).}
+
+\item{name}{Optionally, the name of the packet to scope the query on. This
+will be intersected with \code{scope} arg and is a shorthand way of running
+\code{scope = list(name = "name")}}
+
+\item{dry_run}{Logical, indicating if we should print a summary
+but not make any changes.}
 
 \item{root}{The path to the root directory, or \code{NULL} (the
 default) to search for one from the current working

--- a/tests/testthat/test-location-path.R
+++ b/tests/testthat/test-location-path.R
@@ -191,8 +191,8 @@ test_that("Import complete tree via push into server", {
 
   expect_equal(idx_s$metadata, idx_c$metadata)
   expect_equal(idx_s$unpacked, idx_c$unpacked)
-  expect_equal(idx_s$location$packet, idx_c$location$packet)
-  expect_equal(idx_s$location$hash, idx_c$location$hash)
+  expect_equal(idx_s$location$packet, idx_c$unpacked)
+  expect_setequal(idx_s$location$hash, idx_c$location$hash)
 
   expect_setequal(plan$packet_id, ids)
   files_used <- lapply(ids, function(id) client$index$metadata(id)$files$hash)
@@ -304,8 +304,8 @@ test_that("Push single packet", {
 
   expect_equal(idx_s$metadata, idx_c$metadata)
   expect_equal(idx_s$unpacked, idx_c$unpacked)
-  expect_equal(idx_s$location$packet, idx_c$location$packet)
-  expect_equal(idx_s$location$hash, idx_c$location$hash)
+  expect_equal(idx_s$location$packet, idx_c$unpacked)
+  expect_setequal(idx_s$location$hash, idx_c$location$hash)
 
   expect_equal(plan$packet_id, id)
   files_used <- lapply(id, function(id) client$index$metadata(id)$files$hash)
@@ -455,4 +455,18 @@ test_that("prevent pushing unknown packets", {
   expect_error(
     orderly_location_push("20241023-131946-0260c975", "server", root = client),
     "Trying to push unknown packet: '20241023-131946-0260c975'")
+})
+
+
+test_that("pull metadata after push", {
+  client <- create_temporary_root()
+  id1 <- create_random_packet(client, parameters = list(a = 1))
+  id2 <- create_random_packet(client, parameters = list(a = 2))
+  id3 <- create_random_packet(client, parameters = list(a = 1))
+
+  server <- create_temporary_root(use_file_store = TRUE, path_archive = NULL)
+  orderly_location_add_path("server", path = server$path, root = client)
+
+  plan <- orderly_location_push("parameter:a == 1", "server", root = client)
+  expect_length(orderly_search(location = "server", root = client), 2)
 })

--- a/tests/testthat/test-location-path.R
+++ b/tests/testthat/test-location-path.R
@@ -184,7 +184,7 @@ test_that("Import complete tree via push into server", {
   server <- create_temporary_root(use_file_store = TRUE, path_archive = NULL)
   orderly_location_add_path("server", path = server$path, root = client)
 
-  plan <- orderly_location_push(ids[[4]], "server", client)
+  plan <- orderly_location_push(ids[[4]], "server", root = client)
 
   idx_c <- client$index$data()
   idx_s <- server$index$data()
@@ -208,7 +208,7 @@ test_that("Import packets into root with archive as well as store", {
                                   path_archive = "archive")
   orderly_location_add_path("server", path = server$path, root = client)
 
-  plan <- orderly_location_push(ids[[4]], "server", client)
+  plan <- orderly_location_push(ids[[4]], "server", root = client)
 
   expect_equal(
     sort(withr::with_dir(server$path, fs::dir_ls("archive", recurse = TRUE))),
@@ -257,7 +257,7 @@ test_that("Can only push into a root with a file store", {
   server <- create_temporary_root()
   orderly_location_add_path("server", path = server$path, root = client)
   expect_error(
-    orderly_location_push(ids[[2]], "server", client),
+    orderly_location_push(ids[[2]], "server", root = client),
     "Can't push files into this server, as it does not have a file store")
 })
 
@@ -267,8 +267,8 @@ test_that("pushing twice does nothing", {
   ids <- create_random_packet_chain(client, 4)
   server <- create_temporary_root(use_file_store = TRUE, path_archive = NULL)
   orderly_location_add_path("server", path = server$path, root = client)
-  plan1 <- orderly_location_push(ids[[4]], "server", client)
-  plan2 <- orderly_location_push(ids[[4]], "server", client)
+  plan1 <- orderly_location_push(ids[[4]], "server", root = client)
+  plan2 <- orderly_location_push(ids[[4]], "server", root = client)
   expect_equal(plan2, list(packet_id = character(), files = character()))
 })
 
@@ -283,7 +283,7 @@ test_that("push overlapping tree", {
   suppressMessages(orderly_location_pull_packet(id_base, root = client))
 
   ids <- create_random_packet_chain(client, 3, id_base)
-  plan <- orderly_location_push(ids[[3]], "server", client)
+  plan <- orderly_location_push(ids[[3]], "server", root = client)
 
   expect_setequal(plan$packet_id, ids)
   expect_setequal(names(server$index$data()$metadata), c(id_base, ids))
@@ -297,7 +297,7 @@ test_that("Push single packet", {
   server <- create_temporary_root(use_file_store = TRUE, path_archive = NULL)
   orderly_location_add_path("server", path = server$path, root = client)
 
-  plan <- orderly_location_push(id, "server", client)
+  plan <- orderly_location_push(id, "server", root = client)
 
   idx_c <- client$index$data()
   idx_s <- server$index$data()
@@ -356,7 +356,7 @@ test_that("Fail to push sensibly if files have been changed", {
   forcibly_truncate_file(path)
 
   expect_error(
-    suppressMessages(orderly_location_push(ids[[4]], "server", client)),
+    suppressMessages(orderly_location_push(ids[[4]], "server", root = client)),
     "Did not find suitable file, can't push this packet")
 })
 
@@ -407,4 +407,52 @@ test_that("provide hint when wrong relative path given", {
     "'path' must be given relative to the orderly root")
   expect_equal(err$body[[2]],
                "Consider passing '../b' instead")
+})
+
+
+test_that("Dry run does not push", {
+  client <- create_temporary_root()
+  id1 <- create_random_packet(client, parameters = list(a = 1))
+  id2 <- create_random_packet(client, parameters = list(a = 2))
+  id3 <- create_random_packet(client, parameters = list(a = 1))
+
+  server <- create_temporary_root(use_file_store = TRUE, path_archive = NULL)
+  orderly_location_add_path("server", path = server$path, root = client)
+
+  plan <- orderly_location_push("parameter:a == 1", "server",
+                                dry_run = TRUE, root = client)
+  expect_length(plan$packet_id, 2)
+  expect_length(orderly_search(root = server), 0)
+})
+
+
+test_that("Inform if query matches nothing", {
+  client <- create_temporary_root()
+  server <- create_temporary_root(use_file_store = TRUE, path_archive = NULL)
+  orderly_location_add_path("server", path = server$path, root = client)
+  withr::local_options(orderly.quiet = FALSE)
+
+  res1 <- evaluate_promise(
+    orderly_location_push("parameter:a == 1", "server", root = client))
+  expect_length(res1$messages, 2)
+  expect_match(res1$messages[[1]], "Query returned no packets to push")
+  expect_match(res1$messages[[2]], "Nothing to push, everything up to date")
+  expect_equal(res1$result, list(packet_id = character(), files = character()))
+
+  res2 <- evaluate_promise(
+    orderly_location_push(character(), "server", root = client))
+  expect_length(res2$messages, 1)
+  expect_equal(res2$messages[[1]], res1$messages[[2]])
+  expect_equal(res2$result, res1$result)
+})
+
+
+test_that("prevent pushing unknown packets", {
+  client <- create_temporary_root()
+  server <- create_temporary_root(use_file_store = TRUE, path_archive = NULL)
+  orderly_location_add_path("server", path = server$path, root = client)
+
+  expect_error(
+    orderly_location_push("20241023-131946-0260c975", "server", root = client),
+    "Trying to push unknown packet: '20241023-131946-0260c975'")
 })

--- a/tests/testthat/test-location-path.R
+++ b/tests/testthat/test-location-path.R
@@ -419,10 +419,15 @@ test_that("Dry run does not push", {
   server <- create_temporary_root(use_file_store = TRUE, path_archive = NULL)
   orderly_location_add_path("server", path = server$path, root = client)
 
-  plan <- orderly_location_push("parameter:a == 1", "server",
-                                dry_run = TRUE, root = client)
-  expect_length(plan$packet_id, 2)
+  withr::local_options(orderly.quiet = FALSE)
+  res <- evaluate_promise(
+    orderly_location_push("parameter:a == 1", "server",
+                          dry_run = TRUE, root = client))
+  expect_length(res$result$packet_id, 2)
   expect_length(orderly_search(root = server), 0)
+  expect_length(res$messages, 2)
+  expect_match(res$messages[[1]], "Pushing 2 files for 2 packets")
+  expect_match(res$messages[[2]], "Not making any changes, as 'dry_run = TRUE'")
 })
 
 


### PR DESCRIPTION
A collection of improvements for push

* make it chattier, fixing #143 
* allow a query, fixing #155 
* throw a sensible error if pushing a packet which does not exist (previously just an assertion that was incomprehensible to the user)
* add a `dry_run` argument which informs about what would be done but makes no changes
* pull updated metadata after pushing, fixing #153