### PR TITLE
Support `environment:` from an interactive session.

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: orderly2
 Title: Orderly Next Generation
-Version: 1.99.55
+Version: 1.99.56
 Authors@R: c(person("Rich", "FitzJohn", role = c("aut", "cre"),
                     email = "rich.fitzjohn@gmail.com"),
              person("Robert", "Ashton", role = "aut"),

--- a/R/outpack_helpers.R
+++ b/R/outpack_helpers.R
@@ -113,6 +113,7 @@ orderly_copy_files <- function(expr, files, dest, overwrite = TRUE,
                          location = options$location,
                          allow_remote = options$allow_remote,
                          fetch_metadata = options$fetch_metadata,
+                         envir = envir,
                          root = root)
     if (length(id) > 1) {
       cli::cli_abort(

--- a/tests/testthat/examples/depends-query/depends-query.R
+++ b/tests/testthat/examples/depends-query/depends-query.R
@@ -1,9 +1,11 @@
 orderly2::orderly_parameters(a = NULL, b = NULL, c = NULL)
+
+value <- c
 orderly2::orderly_dependency(
   "parameters",
   paste("latest(parameter:a == this:a &&",
         "parameter:b == this:b &&",
-        "parameter:c == this:c)"),
+        "parameter:c == environment:value)"),
   c(input.rds = "data.rds"))
 orderly2::orderly_artefact("result.rds", description = "Processed data")
 d <- readRDS("input.rds")


### PR DESCRIPTION
The code path for interactive sessions, through orderly_copy_files, was not propagating the environment from the caller to `orderly_search`. The broke support for `environment:`-style queries, but only when running interactively.

In orderly_copy_files (and orderly_dependency), the `envir` parameter actually has two purposes: it provides values for `environment:` and it provides values that are substituted in the file paths to be copied. This dual usage causes a bit of confusion and may be what led to this issue. We may want to tidy up some of this in the future, possibly with the help of rlang's quosures and quasiquotation support.