### PR TITLE
Make orderly_resource docs more explicit

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: orderly2
 Title: Orderly Next Generation
-Version: 1.99.59
+Version: 1.99.60
 Authors@R: c(person("Rich", "FitzJohn", role = c("aut", "cre"),
                     email = "rich.fitzjohn@gmail.com"),
              person("Robert", "Ashton", role = "aut"),

--- a/R/metadata.R
+++ b/R/metadata.R
@@ -155,7 +155,9 @@ static_orderly_description <- function(args) {
 ##'
 ##' @title Declare orderly resources
 ##'
-##' @param files Any number of names of files
+##' @param files Any number of names of files or directories.  If you
+##'   list a directory it is expanded recursively to include all
+##'   subdirectories and files.
 ##'
 ##' @return Invisibly, a character vector of resources included by the
 ##'   call. Don't rely on the order of these files if they are

--- a/man/orderly_resource.Rd
+++ b/man/orderly_resource.Rd
@@ -7,7 +7,9 @@
 orderly_resource(files)
 }
 \arguments{
-\item{files}{Any number of names of files}
+\item{files}{Any number of names of files or directories.  If you
+list a directory it is expanded recursively to include all
+subdirectories and files.}
 }
 \value{
 Invisibly, a character vector of resources included by the


### PR DESCRIPTION
Fixes #203 

This PR mentions directories in the help for the `files` argument to `orderly_resource`