### PR TITLE
Better error message when additional arguments are present in metadata function calls

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: orderly2
 Title: Orderly Next Generation
-Version: 1.99.61
+Version: 1.99.62
 Authors@R: c(person("Rich", "FitzJohn", role = c("aut", "cre"),
                     email = "rich.fitzjohn@gmail.com"),
              person("Robert", "Ashton", role = "aut"),

--- a/R/metadata.R
+++ b/R/metadata.R
@@ -451,7 +451,7 @@ static_eval <- function(fn, expr, call = NULL) {
     expr[[1]] <- expr[[1]][[3]]
   }
   name <- expr[[1]]
-  tryCatch(
+  args <- tryCatch(
     as.list(match.call(match.fun(name), expr))[-1],
     error = function(e) {
       msg <- conditionMessage(e)

--- a/tests/testthat/test-read.R
+++ b/tests/testthat/test-read.R
@@ -139,3 +139,27 @@ test_that("read shared resource", {
 
   expect_null(static_orderly_shared_resource(list(quote(c("a", "b")))))
 })
+
+
+test_that("cope with extra arguments", {
+  tmp <- withr::local_tempfile()
+  writeLines('orderly_artefact("a", "b", "c", "d")', tmp)
+  e <- expect_error(orderly_parse_file(tmp),
+                    "Failed to parse call to 'orderly_artefact()'",
+                    fixed = TRUE)
+  skip_on_cran()
+  msg <- conditionMessage(e)
+  expect_no_match(msg, "Check for a trailing comma")
+})
+
+
+test_that("cope with extra empty arguments", {
+  tmp <- withr::local_tempfile()
+  writeLines('orderly_artefact("a", "b", )', tmp)
+  e <- expect_error(orderly_parse_file(tmp),
+                    "Failed to parse call to 'orderly_artefact()'",
+                    fixed = TRUE)
+  skip_on_cran()
+  msg <- conditionMessage(e)
+  expect_match(msg, "Check for a trailing comma")
+})


### PR DESCRIPTION
Unpleasantness reported by @sangeetabhatia03, with orderly.R ending in:

```
orderly_artefact(
  "qsurveillance_age_rates", "qsurveillance_age_rates.png",
  )
```

which produces an impossible to understand error message of:

```
r$> orderly2::orderly_run('src/plot_age_str_ili_rates/')
Error in match.call(definition, call, expand.dots, envir) : 
  unused argument (alist())
r$> traceback()
6: match.call(match.fun(call[[1]]), call)
5: as.list(match.call(match.fun(call[[1]]), call)[-1])
4: static_eval(check[[nm]], e$expr)
3: orderly_read_r(file.path(path, "orderly.R"))
2: orderly_read(src, environment())
1: orderly2::orderly_run("src/plot_age_str_ili_rates/"
```

The issue is the trailing comma leading to an empty unused arg:

```
f <- function(a, b) NULL
call <- quote(f("a", "b", ))
static_eval(f, call)
```

This PR attempts to intercept this and turn the error into something nicer