### PR TITLE
Fix build

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -43,7 +43,6 @@ jobs:
         with:
           crate: outpack
           git: https://github.com/mrc-ide/outpack_server
-          features: git2/vendored-libgit2
 
       - uses: r-lib/actions/setup-pandoc@v2
 

--- a/.github/workflows/test-coverage.yaml
+++ b/.github/workflows/test-coverage.yaml
@@ -26,7 +26,6 @@ jobs:
         with:
           crate: outpack
           git: https://github.com/mrc-ide/outpack_server
-          features: git2/vendored-libgit2
 
       - uses: r-lib/actions/setup-r@v2
         with:

--- a/.github/workflows/test-coverage.yaml
+++ b/.github/workflows/test-coverage.yaml
@@ -54,7 +54,7 @@ jobs:
 
       - name: Upload test results
         if: failure()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: coverage-test-failures
           path: ${{ runner.temp }}/package

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: orderly2
 Title: Orderly Next Generation
-Version: 1.99.60
+Version: 1.99.61
 Authors@R: c(person("Rich", "FitzJohn", role = c("aut", "cre"),
                     email = "rich.fitzjohn@gmail.com"),
              person("Robert", "Ashton", role = "aut"),


### PR DESCRIPTION
The outpack_server no longer has the `git2/vendored-libgit2` feature (https://github.com/mrc-ide/outpack_server/pull/71), this PR removes the request to install it which allows outpack_server to install again.  Also updates the artifact action version