### PR TITLE
Better behaviour with missing jsonvalidate

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: orderly2
 Title: Orderly Next Generation
-Version: 1.99.62
+Version: 1.99.63
 Authors@R: c(person("Rich", "FitzJohn", role = c("aut", "cre"),
                     email = "rich.fitzjohn@gmail.com"),
              person("Robert", "Ashton", role = "aut"),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -51,7 +51,5 @@ Suggests:
     stringr,
     testthat (>= 3.0.0)
 Config/testthat/edition: 3
-Remotes:
-  ropensci/jsonvalidate
 VignetteBuilder: knitr
 Language: en-GB

--- a/R/schema.R
+++ b/R/schema.R
@@ -22,6 +22,7 @@ load_schema <- function(key) {
       ## orderly2 when it is installed itself as a real package...
       path <- file.path(pkg_root(key_split[[1]]), key_split[[2]])
     }
+    ensure_jsonvalidate()
     cache$schema[[key]] <- jsonvalidate::json_schema$new(path)
   }
   cache$schema[[key]]
@@ -30,4 +31,14 @@ load_schema <- function(key) {
 
 should_validate_schema <- function(schema) {
   !is.null(schema) && getOption("outpack.schema_validate", FALSE)
+}
+
+
+ensure_jsonvalidate <- function() {
+  if (!requireNamespace("jsonvalidate")) {
+    cli::cli_abort(
+      c("The jsonvalidate package is missing, but you have requested it",
+        i = paste("The option 'outpack.schema_validate' is 'TRUE', but you",
+                  "don't have 'jsonvalidate' installed so we can't do this.")))
+  }
 }

--- a/README.md
+++ b/README.md
@@ -66,6 +66,8 @@ install.packages(
 
 Without these, some tests will be skipped, but the suite will still run.
 
+If you want to force validation of schemas during testing, set the R option `outpack.schema_validate` to `TRUE`.  This will automatically be set on CI (as detected by the `CI` environment variable) and will be enabled if `jsonvalidate` is installed.  Set the option `outpack.schema_validate` as `FALSE` to disable checking.
+
 ## Licence
 
 MIT © Imperial College of Science, Technology and Medicine

--- a/tests/testthat/helper-orderly.R
+++ b/tests/testthat/helper-orderly.R
@@ -1,9 +1,3 @@
-options(outpack.schema_validate =
-          requireNamespace("jsonvalidate", quietly = TRUE) &&
-          packageVersion("jsonvalidate") >= "1.4.0",
-        orderly.index_progress = FALSE)
-
-
 test_prepare_orderly_example <- function(examples, ...) {
   tmp <- tempfile()
   withr::defer_parent(fs::dir_delete(tmp))

--- a/tests/testthat/helper-outpack.R
+++ b/tests/testthat/helper-outpack.R
@@ -1,8 +1,3 @@
-## Globally enable schema validation everywhere; really this should be
-## disabled on CRAN, and only enabled if jsonvalidate is found.
-options(outpack.schema_validate = TRUE)
-
-
 create_random_packet <- function(root, name = "data", parameters = NULL,
                                  id = NULL, n_files = 1) {
   src <- fs::dir_create(tempfile())

--- a/tests/testthat/setup.R
+++ b/tests/testthat/setup.R
@@ -1,0 +1,16 @@
+tests_schema_validate <- function() {
+  opt <- getOption("outpack.schema_validate", NULL)
+  if (!is.null(opt)) {
+    return(opt)
+  }
+  if (isTRUE(as.logical(Sys.getenv("CI", "false")))) {
+    return(TRUE)
+  }
+  requireNamespace("jsonvalidate", quietly = TRUE)
+}
+
+
+withr::local_options(
+  orderly.index_progress = FALSE,
+  outpack.schema_validate = tests_schema_validate(),
+  .local_envir = teardown_env())

--- a/tests/testthat/test-outpack-packet.R
+++ b/tests/testthat/test-outpack-packet.R
@@ -30,11 +30,15 @@ test_that("Can run a basic packet", {
 
   path_metadata <- file.path(path, ".outpack", "metadata", id)
   expect_true(file.exists(path_metadata))
-  expect_true(load_schema("outpack/metadata.json")$validate(path_metadata))
+  if (requireNamespace("jsonvalidate", quietly = TRUE)) {
+    expect_true(load_schema("outpack/metadata.json")$validate(path_metadata))
+  }
 
   path_location <- file.path(path, ".outpack", "location", "local", id)
   expect_true(file.exists(path_location))
-  expect_true(load_schema("outpack/location.json")$validate(path_location))
+  if (requireNamespace("jsonvalidate", quietly = TRUE)) {
+    expect_true(load_schema("outpack/location.json")$validate(path_location))
+  }
 
   meta <- outpack_metadata_load(file(path_metadata), NULL)
 
@@ -121,7 +125,9 @@ test_that("Can handle dependencies", {
   meta <- orderly_metadata(id2, root = path)
   path_metadata <- file.path(path, ".outpack", "metadata", id2)
   expect_true(file.exists(path_metadata))
-  expect_true(load_schema("outpack/metadata.json")$validate(path_metadata))
+  if (requireNamespace("jsonvalidate", quietly = TRUE)) {
+    expect_true(load_schema("outpack/metadata.json")$validate(path_metadata))
+  }
 
   expect_equal(
     meta$depends,

--- a/tests/testthat/test-validate.R
+++ b/tests/testthat/test-validate.R
@@ -145,3 +145,15 @@ test_that("don't invalidate children when complete tree off", {
     evaluate_promise(orderly_validate_archive(id3, root = root)),
     res)
 })
+
+
+test_that("can inform sensibly if jsonvalidate is missing", {
+  skip_if_not_installed("mockery")
+  mockery::stub(ensure_jsonvalidate,
+                "requireNamespace",
+                mockery::mock(TRUE, FALSE))
+  expect_no_error(ensure_jsonvalidate())
+  expect_error(
+    ensure_jsonvalidate(),
+    "The jsonvalidate package is missing, but you have requested it")
+})


### PR DESCRIPTION
* adds a sensible error indicating the issue
* ensures that jsonvalidate is definitely used in the tests
* sets up a system so that it's easier to control if we load it
* ensures that the test suite can pass if jsonvalidate is missing