### PR TITLE
Insert known git information into metadata

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: orderly2
 Title: Orderly Next Generation
-Version: 1.99.64
+Version: 1.99.65
 Authors@R: c(person("Rich", "FitzJohn", role = c("aut", "cre"),
                     email = "rich.fitzjohn@gmail.com"),
              person("Robert", "Ashton", role = "aut"),

--- a/R/outpack_metadata.R
+++ b/R/outpack_metadata.R
@@ -63,7 +63,7 @@ orderly_metadata_read <- function(path, plugins = TRUE) {
 }
 
 outpack_metadata_create <- function(path, name, id, time, files,
-                                    depends, parameters, custom,
+                                    depends, parameters, git, custom,
                                     file_hash, file_ignore, hash_algorithm) {
   assert_scalar_character(name)
   assert_scalar_character(id)
@@ -143,10 +143,10 @@ outpack_metadata_create <- function(path, name, id, time, files,
                         vcapply(custom, "[[", "application"))
   }
 
-  git <- git_info(path)
   if (!is.null(git)) {
     git$sha <- scalar(git$sha)
     git$branch <- scalar(git$branch)
+    git$url <- git$url %||% character()
   }
 
   ret <- list(schema_version = scalar(outpack_schema_version()),

--- a/R/outpack_packet.R
+++ b/R/outpack_packet.R
@@ -94,6 +94,7 @@ outpack_packet_end <- function(packet, insert = TRUE) {
                                   files = NULL,
                                   depends = packet$depends,
                                   parameters = packet$parameters,
+                                  git = git_info(packet$path),
                                   custom = packet$custom,
                                   file_hash = packet$files$immutable,
                                   file_ignore = packet$files$ignored,

--- a/tests/testthat/test-outpack-metadata.R
+++ b/tests/testthat/test-outpack-metadata.R
@@ -8,6 +8,7 @@ test_that("Can construct metadata with parameters", {
                                   parameters = parameters,
                                   files = character(),
                                   depends = NULL,
+                                  git = NULL,
                                   custom = NULL,
                                   file_hash = NULL,
                                   file_ignore = NULL)


### PR DESCRIPTION
Moves the location of the git detection from within the metadata creation function into the function that calls it; this will let us migrate git data from existing orderly1 repos