### PR TITLE
Better git checks

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: orderly2
 Title: Orderly Next Generation
-Version: 1.99.67
+Version: 1.99.68
 Authors@R: c(person("Rich", "FitzJohn", role = c("aut", "cre"),
                     email = "rich.fitzjohn@gmail.com"),
              person("Robert", "Ashton", role = "aut"),

--- a/R/root.R
+++ b/R/root.R
@@ -278,6 +278,10 @@ root_validate_same_configuration <- function(args, config, root, call) {
 
 
 root_check_git <- function(root, call) {
+  if (isTRUE(getOption("orderly_git_error_ignore", FALSE))) {
+    return()
+  }
+
   path_ok <- file.path(root$path, ".outpack", "r", "git_ok")
   if (file.exists(path_ok)) {
     return()
@@ -288,21 +292,43 @@ root_check_git <- function(root, call) {
   }
 
   files <- gert::git_ls(git_root)$path
-  files_full <- file.path(gert::git_info(git_root)$path, files)
-  special <- c(".outpack", "draft", root$config$core$path_archive)
-  err <- vapply(special, function(p) {
-    fs::path_has_parent(files_full, file.path(root$path, p))
-  }, logical(length(files)))
+
+  path_root_git <- gert::git_info(git_root)$path
+  special <- paste0(c(".outpack", "draft", root$config$core$path_archive), "/")
+
+  ## We'd like to use fs::path_has_parent here but it's very slow with
+  ## a few thousand files, so we do this with string comparison which
+  ## is muich faster.  For montagu this was taking about 1.3s, vs
+  ## <0.001 with this approach.
+
+  ## This is easiest to do if the outpack rep is at the git root,
+  ## which is the most common situation.
+  path_rel <- fs::path_rel(root$path, path_root_git)
+  if (path_rel != ".") {
+    special <- file.path(path_rel, special)
+  }
+
+  ## Allow draft/README.md and archive/README.md, which are present in
+  ## orderly1 and might be generally ok
+  files <- setdiff(files, file.path(special[-1], "README.md"))
+
+  err <- vapply(special, function(p) startsWith(files, p),
+                logical(length(files)))
+
+  ## Avoid paranoid case of a single file to check not being a matrix.
   dim(err) <- c(length(files), length(special))
 
-  if (any(err)) {
+  is_ok <- !any(err)
+
+  if (!is_ok) {
     files_err <- files[rowSums(err) > 0]
-    types_err <- paste0(special[colSums(err) > 0], "/")
+    types_err <- special[colSums(err) > 0]
     url <- "https://mrc-ide.github.io/orderly2/articles/troubleshooting.html"
     warn_only <- getOption("orderly_git_error_is_warning", FALSE)
     msg <- c("Detected {length(files_err)} outpack file{?s} committed to git",
              x = "Detected files were found in {squote(types_err)}",
-             i = "For tips on resolving this, please see {.url {url}}")
+             i = "For tips on resolving this, please see {.url {url}}",
+             x = "Found: {files_err}")
     if (warn_only) {
       cli::cli_warn(msg, call = call, .frequency = "once",
                     .frequency_id = paste0("orderly_git_warning-", root$path))
@@ -310,13 +336,19 @@ root_check_git <- function(root, call) {
       hint_warn_only <- paste(
         "To turn this into a warning and continue anyway",
         "set the option 'orderly_git_error_is_warning' to TRUE",
-        "by running options(orderly_git_error_is_warning = TRUE)")
+        "by running {.code options(orderly_git_error_is_warning = TRUE)}")
+      hint_disable <- paste(
+        "To disable this check entirely, set the option",
+        "'orderly_git_error_ignore' to TRUE by running",
+        "{.code options(orderly_git_error_ignore = TRUE)}")
       cli::cli_abort(c(msg, i = hint_warn_only), call = call)
     }
   }
 
   do_orderly_gitignore_update("(root)", root$path)
 
-  fs::dir_create(dirname(path_ok))
-  fs::file_create(path_ok)
+  if (is_ok) {
+    fs::dir_create(dirname(path_ok))
+    fs::file_create(path_ok)
+  }
 }

--- a/tests/testthat/test-root.R
+++ b/tests/testthat/test-root.R
@@ -138,6 +138,24 @@ test_that("can error with instructions if files are added to git", {
 })
 
 
+test_that("can do git check in subdir", {
+  ## Make sure that these are never set for the tests
+  withr::local_options(
+    orderly_git_error_is_warning = NULL,
+    orderly_git_error_ignore = NULL)
+
+  path <- withr::local_tempdir()
+  root <- file.path(path, "root")
+  suppressMessages(orderly_init(root))
+
+  info <- helper_add_git(path)
+
+  expect_error(
+    root_check_git(list(path = root), NULL),
+    "Detected 1 outpack file committed to git")
+})
+
+
 test_that("can identify a plain source root", {
   info <- test_prepare_orderly_example_separate("explicit")
   expect_equal(normalise_path(orderly_src_root(info$src, FALSE)),


### PR DESCRIPTION
The current approach has some limitations seen when migrating over the montagu setup:

* it is very slow
* it writes out that things are ok when the error is converted into a warning
* it errors on files that are always present in orderly1 repos