### PR TITLE
Allow copying the entire packet easily

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: orderly2
 Title: Orderly Next Generation
-Version: 1.99.68
+Version: 1.99.69
 Authors@R: c(person("Rich", "FitzJohn", role = c("aut", "cre"),
                     email = "rich.fitzjohn@gmail.com"),
              person("Robert", "Ashton", role = "aut"),

--- a/R/outpack_helpers.R
+++ b/R/outpack_helpers.R
@@ -185,7 +185,8 @@ plan_copy_files <- function(root, id, files, call = NULL) {
     string_drop_prefix(p, meta$files$path[j])
   }
   ret <- expand_dirs_virtual(files, is_dir, list_files)
-  fs::path_norm(ret)
+  ret[] <- lapply(ret, fs::path_norm)
+  ret
 }
 
 

--- a/R/outpack_helpers.R
+++ b/R/outpack_helpers.R
@@ -66,6 +66,10 @@
 ##'   environment in the query is done by using `environment:x` and in
 ##'   the destination filename by doing `${x}`.
 ##'
+##' If you want to copy *all* files from the packet, use `./` (read
+##'   this as the directory of the packet).  The trailing slash is
+##'   required in order to be consistent with the rules above.
+##'
 ##' @param dest The directory to copy into
 ##'
 ##' @param overwrite Overwrite files at the destination; this is
@@ -174,6 +178,9 @@ plan_copy_files <- function(root, id, files, call = NULL) {
   meta <- outpack_metadata_core(id, root)
   is_dir <- function(p) grepl("/$", p)
   list_files <- function(p) {
+    if (p == "./") {
+      return(meta$files$path)
+    }
     j <- string_starts_with(p, meta$files$path)
     string_drop_prefix(p, meta$files$path[j])
   }

--- a/R/outpack_helpers.R
+++ b/R/outpack_helpers.R
@@ -185,14 +185,7 @@ plan_copy_files <- function(root, id, files, call = NULL) {
     string_drop_prefix(p, meta$files$path[j])
   }
   ret <- expand_dirs_virtual(files, is_dir, list_files)
-  ## We could do this correction in expand_dirs_virtual by not
-  ## constructing the path with the leading './' component, but doing
-  ## it here at least centralises the manipulations into this
-  ## function.
-  if (any("./" %in% files)) {
-    ret[] <- lapply(ret, function(x) sub("^\\./", "", x))
-  }
-  ret
+  fs::path_norm(ret)
 }
 
 

--- a/R/outpack_helpers.R
+++ b/R/outpack_helpers.R
@@ -184,7 +184,15 @@ plan_copy_files <- function(root, id, files, call = NULL) {
     j <- string_starts_with(p, meta$files$path)
     string_drop_prefix(p, meta$files$path[j])
   }
-  expand_dirs_virtual(files, is_dir, list_files)
+  ret <- expand_dirs_virtual(files, is_dir, list_files)
+  ## We could do this correction in expand_dirs_virtual by not
+  ## constructing the path with the leading './' component, but doing
+  ## it here at least centralises the manipulations into this
+  ## function.
+  if (any("./" %in% files)) {
+    ret[] <- lapply(ret, function(x) sub("^\\./", "", x))
+  }
+  ret
 }
 
 

--- a/R/outpack_helpers.R
+++ b/R/outpack_helpers.R
@@ -185,7 +185,7 @@ plan_copy_files <- function(root, id, files, call = NULL) {
     string_drop_prefix(p, meta$files$path[j])
   }
   ret <- expand_dirs_virtual(files, is_dir, list_files)
-  ret[] <- lapply(ret, fs::path_norm)
+  ret[] <- lapply(ret, function(x) as.character(fs::path_norm(x)))
   ret
 }
 

--- a/R/outpack_misc.R
+++ b/R/outpack_misc.R
@@ -115,5 +115,11 @@ validate_file_from_to <- function(x, envir,
       call = call)
   }
 
+  if (any(from == ".")) {
+    cli::cli_abort(
+      "Invalid file '.' in {name}, did you mean './' (with a trailing slash)",
+      call = call)
+  }
+
   data_frame(here = to_value, there = from)
 }

--- a/R/outpack_misc.R
+++ b/R/outpack_misc.R
@@ -117,7 +117,7 @@ validate_file_from_to <- function(x, envir,
 
   if (any(from == ".")) {
     cli::cli_abort(
-      "Invalid file '.' in {name}, did you mean './' (with a trailing slash)",
+      "Invalid file '.' in {name}, did you mean './' (with a trailing slash)?",
       call = call)
   }
 

--- a/R/outpack_root.R
+++ b/R/outpack_root.R
@@ -166,7 +166,7 @@ validate_packet_has_file <- function(root, id, path, call = NULL) {
   is_dir <- grepl("/$", path)
   found <- path %in% files
   found[is_dir] <- vlapply(
-    path[is_dir], function(x) any(string_starts_with(x, files)),
+    path[is_dir], function(x) x == "./" || any(string_starts_with(x, files)),
     USE.NAMES = FALSE)
 
   if (all(found)) {

--- a/R/util.R
+++ b/R/util.R
@@ -158,13 +158,17 @@ expand_dirs_virtual <- function(files, is_dir, list_files) {
     expanded <- lapply(files[dirs], list_files)
     replace_ragged(files, dirs, Map(fs::path, files[dirs], expanded))
   } else {
+    fs_path <- function(a, b) {
+      if (a == "./") b else fs::path(a, b)
+    }
+
     dirs <- is_dir(files$there)
     expanded <- lapply(files$there[dirs], list_files)
 
     there <- replace_ragged(files$there, dirs,
-                            Map(fs::path, files$there[dirs], expanded))
+                            Map(fs_path, files$there[dirs], expanded))
     here <- replace_ragged(files$here, dirs,
-                           Map(fs::path, files$here[dirs], expanded))
+                           Map(fs_path, files$here[dirs], expanded))
 
     data_frame(here, there)
   }

--- a/R/util.R
+++ b/R/util.R
@@ -158,17 +158,13 @@ expand_dirs_virtual <- function(files, is_dir, list_files) {
     expanded <- lapply(files[dirs], list_files)
     replace_ragged(files, dirs, Map(fs::path, files[dirs], expanded))
   } else {
-    fs_path <- function(a, b) {
-      if (a == "./") b else fs::path(a, b)
-    }
-
     dirs <- is_dir(files$there)
     expanded <- lapply(files$there[dirs], list_files)
 
     there <- replace_ragged(files$there, dirs,
-                            Map(fs_path, files$there[dirs], expanded))
+                            Map(fs::path, files$there[dirs], expanded))
     here <- replace_ragged(files$here, dirs,
-                           Map(fs_path, files$here[dirs], expanded))
+                           Map(fs::path, files$here[dirs], expanded))
 
     data_frame(here, there)
   }

--- a/man/orderly_copy_files.Rd
+++ b/man/orderly_copy_files.Rd
@@ -48,7 +48,11 @@ or other fancy features supported.
 Note that there is an unfortunate, but (to us) avoidable
 inconsistency here; interpolation of values from your
 environment in the query is done by using \code{environment:x} and in
-the destination filename by doing \verb{$\{x\}}.}
+the destination filename by doing \verb{$\{x\}}.
+
+If you want to copy \emph{all} files from the packet, use \verb{./} (read
+this as the directory of the packet).  The trailing slash is
+required in order to be consistent with the rules above.}
 
 \item{dest}{The directory to copy into}
 

--- a/man/orderly_dependency.Rd
+++ b/man/orderly_dependency.Rd
@@ -39,7 +39,11 @@ or other fancy features supported.
 Note that there is an unfortunate, but (to us) avoidable
 inconsistency here; interpolation of values from your
 environment in the query is done by using \code{environment:x} and in
-the destination filename by doing \verb{$\{x\}}.}
+the destination filename by doing \verb{$\{x\}}.
+
+If you want to copy \emph{all} files from the packet, use \verb{./} (read
+this as the directory of the packet).  The trailing slash is
+required in order to be consistent with the rules above.}
 }
 \value{
 Undefined

--- a/tests/testthat/test-outpack-helpers.R
+++ b/tests/testthat/test-outpack-helpers.R
@@ -188,3 +188,19 @@ test_that("Can overwrite when copying files from packet", {
     readRDS(file.path(dst, "data.rds")),
     readRDS(file.path(root$path, "archive", "data", id2, "data.rds")))
 })
+
+
+test_that("can copy complete directory", {
+  path <- test_prepare_orderly_example("directories")
+  envir <- new.env()
+  id <- orderly_run_quietly("directories", root = path, envir = envir)
+  meta <- orderly_metadata(id, root = path)
+
+  dst <- temp_file()
+  res <-  orderly_copy_files(
+    id, files = "./", dest = dst, root = path)
+
+  expect_equal(res$files$here, res$files$there)
+  expect_true(all(file.exists(file.path(dst, res$files$here))))
+  expect_setequal(list.files(dst, recursive = TRUE), res$files$here)
+})

--- a/tests/testthat/test-outpack-helpers.R
+++ b/tests/testthat/test-outpack-helpers.R
@@ -200,6 +200,7 @@ test_that("can copy complete directory", {
   res <-  orderly_copy_files(
     id, files = "./", dest = dst, root = path)
 
+  expect_setequal(res$files$here, meta$files$path)
   expect_equal(res$files$here, res$files$there)
   expect_true(all(file.exists(file.path(dst, res$files$here))))
   expect_setequal(list.files(dst, recursive = TRUE), res$files$here)

--- a/tests/testthat/test-outpack-misc.R
+++ b/tests/testthat/test-outpack-misc.R
@@ -106,4 +106,11 @@ test_that("can validate file renaming inputs", {
     validate_file_from_to(c("a" = "x", "a" = "y"), envir, "files"),
     "Every destination filename (in 'files') must be unique",
     fixed = TRUE)
+
+  expect_error(
+    validate_file_from_to(".", envir, "files"),
+    "Invalid file '.' in files, did you mean './'")
+  expect_error(
+    validate_file_from_to(c("a", "b", ".", "c", "d"), envir, "files"),
+    "Invalid file '.' in files, did you mean './'")
 })


### PR DESCRIPTION
This PR expands functionality of `orderly_copy_files` to copy whole directories; this was surprisingly annoying to do because it breaks checks that files exist.  For consistency with handling of subdirectories, I've required `./` rather than `.` so that it's explicit that a directory is expected. 