### PR TITLE
Better file export with duplicated names

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: orderly2
 Title: Orderly Next Generation
-Version: 1.99.69
+Version: 1.99.70
 Authors@R: c(person("Rich", "FitzJohn", role = c("aut", "cre"),
                     email = "rich.fitzjohn@gmail.com"),
              person("Robert", "Ashton", role = "aut"),


### PR DESCRIPTION
This is seen in some work with montagu because there are packets with duplicated filenames (see https://github.com/mrc-ide/orderly2/pull/214/files#diff-5c6f42bac4319b66a372a7a8bcfc1ea7724f4248958c0e46c98a4685c16c61f4 for details; the next time we run that migration these will disappear but older orderly2-derived packets will suffer from this too).

This PR checks that the file from/to combinations we have been given *after directory expansion* are unique, but allows for a from/to pair to be multiply listed.  So it's ok to copy a twice but it's not ok to copy both a and b to a.