### PR TITLE
Perform device flow authentication against Packit.

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: orderly2
 Title: Orderly Next Generation
-Version: 1.99.70
+Version: 1.99.71
 Authors@R: c(person("Rich", "FitzJohn", role = c("aut", "cre"),
                     email = "rich.fitzjohn@gmail.com"),
              person("Robert", "Ashton", role = "aut"),
@@ -42,6 +42,7 @@ Imports:
 Suggests:
     DBI,
     RSQLite,
+    callr,
     jsonvalidate (>= 1.4.0),
     knitr,
     mockery,
@@ -49,7 +50,8 @@ Suggests:
     processx,
     rmarkdown,
     stringr,
-    testthat (>= 3.0.0)
+    testthat (>= 3.0.0),
+    webfakes
 Config/testthat/edition: 3
 VignetteBuilder: knitr
 Language: en-GB

--- a/R/location_http.R
+++ b/R/location_http.R
@@ -4,8 +4,8 @@ orderly_location_http <- R6::R6Class(
   public = list(
     client = NULL,
 
-    initialize = function(url, authorise = NULL) {
-      self$client <- outpack_http_client$new(url, authorise)
+    initialize = function(url, customize = identity) {
+      self$client <- outpack_http_client$new(url, customize)
     },
 
     verify = function() {
@@ -18,10 +18,6 @@ orderly_location_http <- R6::R6Class(
       ## the most likely source of errors (along with getting the URL
       ## wrong).
       stopifnot(identical(self$client$request("/")$status, "success"))
-    },
-
-    authorise = function() {
-      self$client$authorise()
     },
 
     list = function() {

--- a/R/location_packit.R
+++ b/R/location_packit.R
@@ -20,7 +20,8 @@ url_append <- function(url, path) {
 #
 # This function is copied from httr2's req_oauth_device, just switching out the
 # flow function.  Unfortunately it involves poking at some unexported API for
-# the cache. We should just upstream this (as an option maybe) at some point.
+# the cache. Once https://github.com/r-lib/httr2/pull/763 is released, we should
+# be able to get rid of this and set `open_browser = FALSE`.
 req_oauth_device_noninteractive <- function(
   req, client, auth_url, scope = NULL, auth_params = list(),
   token_params = list(), cache_disk = FALSE, cache_key = NULL) {

--- a/R/location_packit.R
+++ b/R/location_packit.R
@@ -1,72 +1,92 @@
-github_oauth_client <- function() {
-  # Surprisingly, we don't actually need the Client ID here to match the one
-  # used by Packit. It should be fine to hardcode a value regardless of which
-  # server we are talking to.
-  httr2::oauth_client(
-    id = "Ov23liUrbkR0qUtAO1zu",
-    token_url = "https://github.com/login/oauth/access_token",
-    name = "orderly2"
+# This has the same semantics as httr2::req_url_path_append and is mostly just
+# copied from there. It always adds the argument to the end of the URL, adding
+# a slash only when necessary.
+url_append <- function(url, path) {
+  path <- sub("^([^/])", "/\\1", path)
+
+  url <- httr2::url_parse(url)
+  url$path <- paste0(sub("/$", "", url$path), path)
+  httr2::url_build(url)
+}
+
+# httr2 has a pretty unintuitive output when running interactively.  It waits
+# for the user to press <Enter> and then opens up a browser, but the wording
+# isn't super clear. It also does not work at all if a browser can't be opened,
+# eg. in an SSH session.
+#
+# Thankfully, if we pretend to not be interactive the behaviour is a lot more
+# obvious. It will just print the link to the console and with instructions for
+# the user to open it up.
+#
+# This function is copied from httr2's req_oauth_device, just switching out the
+# flow function.  Unfortunately it involves poking at some unexported API for
+# the cache. We should just upstream this (as an option maybe) at some point.
+req_oauth_device_noninteractive <- function(
+  req, client, auth_url, scope = NULL, auth_params = list(),
+  token_params = list(), cache_disk = FALSE, cache_key = NULL) {
+  params <- list(
+    client = client,
+    auth_url = auth_url,
+    scope = scope,
+    auth_params = auth_params,
+    token_params = token_params
   )
-}
+  cache <- httr2:::cache_choose(client, cache_disk, cache_key)
 
-do_oauth_device_flow <- function(base_url, cache_disk) {
-  # httr2 has a pretty unintuitive output when running interactively.
-  # It waits for the user to press <Enter> and then opens up a browser, but the
-  # wording isn't super clear. It also does not work at all if a browser can't
-  # be opened, eg. in an SSH session.
-  #
-  # Thankfully, if we pretend to not be interactive the behaviour is a lot more
-  # obvious. It will just print the link to the console and with instructions
-  # for the user to open it up.
-  res <- rlang::with_interactive(value = FALSE, {
-    httr2::oauth_token_cached(
-      client = github_oauth_client(),
-      flow = httr2::oauth_flow_device,
-      flow_params = list(
-        auth_url = "https://github.com/login/device/code",
-        scope = "read:org"),
-      cache_disk = cache_disk)
-  })
-  res$access_token
-}
-
-# Logging in with packit is quite slow and we'll want to cache this; but we
-# won't be holding a persistent handle to the root.  So for now at least we'll
-# keep a pool of generated bearer token headers, stored against the hash of the
-# auth details. We only store this on successful login.
-#
-# This does mean there's no way to flush the cache and force a login, but that
-# should hopefully not be that big a problem.  We'll probably want to refresh
-# the tokens from the request anyway.
-#
-# It also means the user cannot easily use two different identities on the same
-# server from within the same session.
-auth_cache <- new.env(parent = emptyenv())
-packit_authorisation <- function(base_url, token, save_token) {
-  # If a non-Github token is provided, we assume it is a native Packit token
-  # and use that directly.
-  if (!is.null(token) && !grepl("^gh._", token)) {
-    return(list("Authorization" = paste("Bearer", token)))
+  flow <- function(...) {
+    rlang::with_interactive(value = FALSE, httr2::oauth_flow_device(...))
   }
+  httr2::req_oauth(req, flow, params, cache = cache)
+}
 
-  key <- rlang::hash(list(base_url = base_url, token = token))
+# This returns a function that modifies a httr2 request object, adding whatever
+# authentication mechanism is appropriate.
+packit_authentication <- function(base_url, token, save_token) {
+  if (is.null(token)) {
+    auth_url <- url_append(base_url, "deviceAuth")
+    token_url <- url_append(base_url, "deviceAuth/token")
 
-  if (is.null(auth_cache[[key]])) {
-    cli_alert_info("Logging in to {base_url}")
-    if (is.null(token)) {
-      token <- do_oauth_device_flow(base_url, cache_disk = save_token)
+    # Packit actually ignores the Client ID. We can use whatever.
+    #
+    # The `name` argument is used by httr2 to pick the cache location. They
+    # recommend using the package name.
+    client <- httr2::oauth_client(
+      id = "orderly2",
+      token_url = token_url,
+      name = "orderly2"
+    )
+
+    function(r) {
+      # The cache_key is needed to differentiate between different Packit
+      # instances and not mix tokens.
+      #
+      # It also sets us apart from previous version of orderly which performed
+      # OAuth authentication against GitHub instead of Packit, and has a NULL
+      # cache_key. We don't want to accidentally use an old cached GitHub token
+      # in place of a Packit one.
+      req_oauth_device_noninteractive(
+        r, client, auth_url,
+        cache_disk = save_token,
+        cache_key = base_url)
+    }
+  } else {
+    if (grepl("^\\$", token)) {
+      token_variable <- sub("^\\$", "", token)
+      token <- Sys.getenv(token_variable, NA_character_)
+      if (is.na(token)) {
+        cli::cli_abort("Environment variable '{token_variable}' was not set")
+      }
     }
 
-    login_url <- paste0(base_url, "packit/api/auth/login/api")
-    res <- http_client_request(
-      login_url,
-      function(r) http_body_json(r, list(token = scalar(token))))
+    if (grepl("^gh._", token)) {
+      cli::cli_abort(c(
+        "Using a GitHub token to login to Packit isn't supported anymore.",
+        "i" = paste("Either use a Packit token or omit the token",
+                    "to use interactive authentication..")))
+    }
 
-    cli_alert_success("Logged in successfully")
-
-    auth_cache[[key]] <- list("Authorization" = paste("Bearer", res$token))
+    function(req) httr2::req_auth_bearer_token(req, token)
   }
-  auth_cache[[key]]
 }
 
 orderly_location_packit <- function(url, token = NULL, save_token = TRUE) {
@@ -74,20 +94,9 @@ orderly_location_packit <- function(url, token = NULL, save_token = TRUE) {
   assert_scalar_character(token, allow_null = TRUE)
   assert_scalar_logical(save_token)
 
-  if (!is.null(token) && grepl("^\\$", token)) {
-    token_variable <- sub("^\\$", "", token)
-    token <- Sys.getenv(token_variable, NA_character_)
-    if (is.na(token)) {
-      cli::cli_abort(
-        "Environment variable '{token_variable}' was not set")
-    }
-  }
-
-  if (!grepl("/$", url)) {
-    url <- paste0(url, "/")
-  }
+  api_url <- url_append(url, "packit/api")
 
   orderly_location_http$new(
-    paste0(url, "packit/api/outpack"),
-    function() packit_authorisation(url, token, save_token))
+    url_append(api_url, "outpack"),
+    customize = packit_authentication(api_url, token, save_token))
 }

--- a/R/outpack_http_client.R
+++ b/R/outpack_http_client.R
@@ -3,24 +3,19 @@ outpack_http_client <- R6::R6Class(
 
   public = list(
     url = NULL,
-    authorise = NULL,
+    customize = NULL,
 
-    initialize = function(url, authorise = NULL) {
+    initialize = function(url, customize = identity) {
       self$url <- sub("/$", "", url)
-      if (is.null(authorise)) {
-        self$authorise <- function() NULL
-      } else {
-        self$authorise <- authorise
-      }
+      self$customize <- customize
     },
 
     request = function(path, customize = identity, ...) {
-      auth_headers <- self$authorise()
       http_client_request(
         self$url,
         function(r) {
           r <- httr2::req_url_path_append(r, path)
-          r <- httr2::req_headers(r, !!!auth_headers)
+          r <- self$customize(r)
           customize(r)
         }, ...)
     }

--- a/tests/testthat/helper-outpack-http.R
+++ b/tests/testthat/helper-outpack-http.R
@@ -39,11 +39,6 @@ json_string <- function(s) {
   s
 }
 
-
-clear_auth_cache <- function() {
-  rm(list = ls(auth_cache), envir = auth_cache)
-}
-
 local_mock_response <- function(..., env = rlang::caller_env(), cycle = FALSE) {
   mock <- mockery::mock(mock_response(...), cycle = cycle)
   httr2::local_mocked_responses(function(req) mock(req), env = env)

--- a/tests/testthat/test-location-packit.R
+++ b/tests/testthat/test-location-packit.R
@@ -1,169 +1,230 @@
-test_that("can authenticate with existing GitHub token", {
-  withr::local_options(orderly.quiet = FALSE)
-  clear_auth_cache()
-  withr::defer(clear_auth_cache())
+# httr2's built-in mocking functionality operates at a too high level and
+# doesn't receive the authentication details that we are interested in testing.
+#
+# As far as I can tell, the only way to do this properly is by running a full
+# HTTP server and make requests to it. The webfakes package helps us in this.
+#
+# Unfortunately, as the server runs in a separate process, there is no easy way
+# to write assertions against the contents of the request. Because of this, the
+# server records metadata about requests and exposes the last request under
+# `/last/:name`. The test process can hit that endpoint to see the contents of
+# the request. Similary, tokens are managed using the `/token/:name` and
+# `/count` endpoints.
+packit_app <- function() {
+  app <- webfakes::new_app()
+  app$locals$requests <- list()
+  app$locals$tokens <- list()
+  app$locals$token_count <- 0
 
+  # We can't use a simple `/instance/:name` pattern because of
+  # https://github.com/r-lib/webfakes/issues/120
+  app$get(
+    webfakes::new_regexp("/instance/(?<name>[a-z]+)/packit/api/outpack/"),
+    function(req, res) {
+      # HTTP headers is actually all the tests care about. We could capture more
+      # of the request if needed.
+      req$app$locals$requests[[req$params$name]] <- list(
+        headers = req$headers
+      )
+      res$send_json(list(status = "success"), auto_unbox = TRUE)
+    })
+  app$post("/instance/:name/packit/api/deviceAuth", function(req, res) {
+    res$send_json(list(
+      device_code = "xxx",
+      user_code = "yyy",
+      verification_uri = "zzz",
+      expires_in = 3600,
+      interval = 0
+    ), auto_unbox = TRUE)
+  })
+  app$post("/instance/:name/packit/api/deviceAuth/token", function(req, res) {
+    app$locals$token_count <- app$locals$token_count + 1
+    res$send_json(
+      list(
+        access_token = res$app$locals$tokens[[req$params$name]],
+        token_type = "bearer"),
+      auto_unbox = TRUE)
+  })
+  app$get("/last/:name", function(req, res) {
+    res$send_json(res$app$locals$requests[[req$params$name]], auto_unbox = TRUE)
+  })
+  app$post("/token/:name", function(req, res) {
+    res$app$locals$tokens[[req$params$name]] <- req$query$value
+    res$send_status(200)
+  })
+  app$get("/count", function(req, res) {
+    res$send_json(app$locals$token_count, auto_unbox = TRUE)
+  })
+  app
+}
+
+# Setting up the app is a bit slow so we use a single instance of it across all
+# tests in the file.
+packit <- webfakes::local_app_process(packit_app())
+packit_url <- function(name = "default") {
+  packit$url(paste0("/instance/", name, "/"))
+}
+
+last_request <- function(name = "default") {
+  httr2::request(packit$url()) |>
+    httr2::req_url_path_append("last", name) |>
+    httr2::req_perform() |>
+    httr2::resp_body_json()
+}
+
+# Configure the mock server to reply to an authentication attempt with the
+# given token.
+set_device_flow_token <- function(token, name = "default") {
+  httr2::request(packit$url()) |>
+    httr2::req_method("POST") |>
+    httr2::req_url_path_append("token", name) |>
+    httr2::req_url_query(value = token) |>
+    httr2::req_perform()
+}
+
+# Get the number of tokens issued while the argument is evaluated.
+#
+# Because we use a single long-running app, we need to take the difference in
+# count from before and after.
+count_issued_tokens <- function(f) {
+  req <- httr2::request(packit$url("/count"))
+
+  before <- req |> httr2::req_perform() |> httr2::resp_body_json()
+  force(f)
+  after <- req |> httr2::req_perform() |> httr2::resp_body_json()
+
+  after - before
+}
+
+# Set the httr2 on-disk cache to a temporary directory.
+local_oauth_cache <- function(.local_envir = parent.frame()) {
+  path <- withr::local_tempdir(.local_envir = .local_envir)
+  withr::local_envvar("HTTR2_OAUTH_CACHE" = path, .local_envir = .local_envir)
+}
+
+send_packit_request <- function(...) {
+  # The oauth process is a bit more chatty than what we want for tests.
+  suppressMessages({
+    # The fully-qualified is need to be able to use this with callr.
+    orderly2:::orderly_location_packit(...)$verify()
+  })
+}
+
+test_that("Cannot authenticate with GitHub token", {
   token <- "ghp_github-token"
-
-  mock_post <- local_mock_response(
-    to_json(list(token = jsonlite::unbox("my-packit-token"))),
-    wrap = FALSE)
-
-  res <- evaluate_promise(packit_authorisation("http://example.com/", token))
-
-  expect_length(res$messages, 2)
-  expect_match(res$messages[[1]], "Logging in to http://example.com")
-  expect_match(res$messages[[2]], "Logged in successfully")
-  expect_equal(res$result,
-               list("Authorization" = paste("Bearer", "my-packit-token")))
-
-  mockery::expect_called(mock_post, 1)
-  args <- mockery::mock_args(mock_post)[[1]]
-  expect_equal(args[[1]]$url, "http://example.com/packit/api/auth/login/api")
-  expect_equal(args[[1]]$body$data, list(token = scalar("ghp_github-token")))
-  expect_equal(args[[1]]$body$type, "json")
-
-  ## And a second time, does not call mock_post again:
-  res2 <- expect_silent(
-    packit_authorisation("http://example.com/", token))
-  expect_equal(res2, res$result)
-  mockery::expect_called(mock_post, 1)
+  expect_error(
+    orderly_location_packit("http://example.com", token),
+    "Using a GitHub token to login to Packit isn't supported anymore.")
 })
 
-
-test_that("can authenticate with existing Packit token", {
-  clear_auth_cache()
-  withr::defer(clear_auth_cache())
-
+test_that("Can authenticate with an existing Packit token", {
+  local_oauth_cache()
   token <- "my-packit-token"
 
-  result <- packit_authorisation("http://example.com/", token)
-  expect_equal(result,
-               list("Authorization" = paste("Bearer", "my-packit-token")))
+  send_packit_request(packit_url(), token)
+
+  expect_equal(last_request()$headers$Authorization, "Bearer my-packit-token")
 })
 
+test_that("Can create a packit location using an environment variable token", {
+  withr::local_envvar(PACKIT_TOKEN = "packit-token-from-env")
 
-test_that("can authenticate using device flow", {
-  withr::local_options(orderly.quiet = FALSE)
-  clear_auth_cache()
-  withr::defer(clear_auth_cache())
+  send_packit_request(packit_url(), "$PACKIT_TOKEN")
 
-  mock_post <- local_mock_response(
-    to_json(list(token = jsonlite::unbox("my-packit-token"))),
-    wrap = FALSE)
-
-  mockery::stub(packit_authorisation, "do_oauth_device_flow",
-                "ghp_github-token")
-
-  res <- evaluate_promise(packit_authorisation("http://example.com/",
-                                               token = NULL,
-                                               save_token = TRUE))
-
-  expect_length(res$messages, 2)
-  expect_match(res$messages[[1]], "Logging in to http://example.com")
-  expect_match(res$messages[[2]], "Logged in successfully")
-  expect_equal(res$result,
-               list("Authorization" = paste("Bearer", "my-packit-token")))
-
-  mockery::expect_called(mock_post, 1)
-  args <- mockery::mock_args(mock_post)[[1]]
-  expect_equal(args[[1]]$url, "http://example.com/packit/api/auth/login/api")
-  expect_equal(args[[1]]$body$data, list(token = scalar("ghp_github-token")))
-  expect_equal(args[[1]]$body$type, "json")
+  req <- last_request()
+  expect_equal(req$headers$Authorization, "Bearer packit-token-from-env")
 })
 
-
-test_that("location_packit uses authentication", {
-  withr::local_options(orderly.quiet = FALSE)
-  clear_auth_cache()
-  withr::defer(clear_auth_cache())
-
-  token <- "ghp_github-token"
-  id <- outpack_id()
-  metadata <- "packet metadata"
-
-  mock_login <- mock_response(
-    to_json(list(token = jsonlite::unbox("my-packit-token"))),
-    wrap = FALSE)
-  mock_get <- mock_response(metadata)
-  mock <- mockery::mock(mock_login, mock_get)
-  httr2::local_mocked_responses(function(req) mock(req))
-
-  location <- orderly_location_packit("http://example.com", token)
-  res <- evaluate_promise(location$metadata(id))
-
-  expect_length(res$messages, 2)
-  expect_match(res$messages[[1]], "Logging in to http://example.com")
-  expect_match(res$messages[[2]], "Logged in successfully")
-  expect_equal(res$result, setNames(metadata, id))
-
-  mockery::expect_called(mock, 2)
-
-  args <- mockery::mock_args(mock)[[1]]
-  expect_equal(args[[1]]$url, "http://example.com/packit/api/auth/login/api")
-  expect_equal(args[[1]]$body$data, list(token = scalar("ghp_github-token")))
-  expect_equal(args[[1]]$body$type, "json")
-
-  args <- mockery::mock_args(mock)[[2]]
-  expect_match(args[[1]]$url,
-               "http://example.com/packit/api/outpack/metadata/.*/text")
-  expect_equal(args[[1]]$headers,
-               list(Authorization = "Bearer my-packit-token"),
-               ignore_attr = TRUE)
-
-  mock <- mockery::mock(mock_login, mock_get)
+test_that("Error if token variable not found", {
+  withr::local_envvar(PACKIT_TOKEN = NA_character_)
+  expect_error(
+    orderly_location_packit(packit_url(), "$PACKIT_TOKEN"),
+    "Environment variable 'PACKIT_TOKEN' was not set")
 })
 
+test_that("Can authenticate using device flow", {
+  local_oauth_cache()
+  set_device_flow_token("device-packit-token")
 
-test_that("Can configure oauth caching behaviour", {
-  clear_auth_cache()
-  withr::defer(clear_auth_cache())
+  send_packit_request(packit_url())
 
-  mock_token <- mockery::mock("token", cycle = TRUE)
-  testthat::local_mocked_bindings(do_oauth_device_flow = mock_token)
-
-  local_mock_response(to_json(list(token = jsonlite::unbox("my-packit-token"))),
-                      cycle = TRUE)
-
-  location <- orderly_location_packit("http://example.com", save_token = TRUE)
-  suppressMessages(location$client$authorise())
-
-  clear_auth_cache()
-
-  location <- orderly_location_packit("http://example.com", save_token = FALSE)
-  suppressMessages(location$client$authorise())
-
-  mockery::expect_called(mock_token, 2)
-  args <- mockery::mock_args(mock_token)
-  expect_equal(args[[1]]$cache_disk, TRUE)
-  expect_equal(args[[2]]$cache_disk, FALSE)
+  expect_equal(last_request()$headers$Authorization,
+               "Bearer device-packit-token")
 })
 
+test_that("Authentication is cached", {
+  local_oauth_cache()
+  set_device_flow_token("device-packit-token")
 
-test_that("can create a packit location using an environment variable token", {
-  loc <- withr::with_envvar(
-    c("GITHUB_TOKEN" = "ghp_abc123"),
-    orderly_location_packit("http://example.com", "$GITHUB_TOKEN"))
-
-  mock_login <- local_mock_response(
-    to_json(list(token = jsonlite::unbox("my-packit-token"))),
-    wrap = FALSE)
-
-  evaluate_promise(loc$client$authorise())
-
-  mockery::expect_called(mock_login, 1)
-
-  args <- mockery::mock_args(mock_login)[[1]]
-  expect_equal(args[[1]]$url, "http://example.com/packit/api/auth/login/api")
-  expect_equal(args[[1]]$body$data, list(token = scalar("ghp_abc123")))
-  expect_equal(args[[1]]$body$type, "json")
+  n <- count_issued_tokens({
+    send_packit_request(packit_url())
+    send_packit_request(packit_url())
+  })
+  expect_equal(n, 1)
 })
 
+test_that("Authentication cache is keyed by server URL", {
+  local_oauth_cache()
 
-test_that("error if token variable not found", {
-  withr::with_envvar(
-    c("PACKIT_TOKEN" = NA_character_),
-    expect_error(
-      orderly_location_packit("https://example.com", "$PACKIT_TOKEN"),
-      "Environment variable 'PACKIT_TOKEN' was not set"))
+  set_device_flow_token(token = "token-foo", name = "foo")
+  set_device_flow_token(token = "token-bar", name = "bar")
+
+  n <- count_issued_tokens({
+    send_packit_request(packit_url(name = "foo"))
+    send_packit_request(packit_url(name = "bar"))
+  })
+
+  expect_equal(n, 2)
+  expect_equal(last_request("foo")$headers$Authorization, "Bearer token-foo")
+  expect_equal(last_request("bar")$headers$Authorization, "Bearer token-bar")
+})
+
+# This tests checks that the authentication cache is saved to disk and not just
+# memory. It works using callr to start sub-processes that will each try to
+# connect to Packit. The sub-processes are needed to make sure we aren't just
+# hitting the in-memory cache.
+test_that("Authentication cache persists across sessions", {
+  local_oauth_cache()
+
+  set_device_flow_token("first-token")
+  callr::r(send_packit_request, args = list(url = packit_url()))
+  expect_equal(last_request()$headers$Authorization, "Bearer first-token")
+
+  set_device_flow_token("second-token")
+  n <- count_issued_tokens({
+    callr::r(send_packit_request, args = list(url = packit_url()))
+  })
+  # No authentication took place. The client still uses the first token it got.
+  expect_equal(n, 0)
+  expect_equal(last_request()$headers$Authorization, "Bearer first-token")
+})
+
+test_that("On-disk authentication cache can be disabled", {
+  local_oauth_cache()
+
+  set_device_flow_token("first-token")
+  n <- count_issued_tokens({
+    callr::r(function(f, ...) {
+      f(..., save_token = FALSE)
+      f(..., save_token = FALSE)
+    }, args = list(f = send_packit_request, url = packit_url()))
+  })
+
+  # The in-memory cache is still effective. We only had one authentication
+  # attempt, in spite of the two requests.
+  expect_equal(n, 1)
+  expect_equal(last_request()$headers$Authorization, "Bearer first-token")
+
+  set_device_flow_token("second-token")
+  n <- count_issued_tokens({
+    callr::r(function(f, ...) {
+      f(..., save_token = FALSE)
+      f(..., save_token = FALSE)
+    }, args = list(f = send_packit_request, url = packit_url()))
+  })
+
+  # Unlike the earlier test, the token is not reused across sessions and a new
+  # one is obtained.
+  expect_equal(n, 1)
+  expect_equal(last_request()$headers$Authorization, "Bearer second-token")
 })

--- a/tests/testthat/test-location.R
+++ b/tests/testthat/test-location.R
@@ -882,9 +882,8 @@ test_that("cope with trailing slash in url if needed", {
 })
 
 
-test_that("can create an outpack location, disabling auth", {
+test_that("can create an outpack location", {
   loc <- orderly_location_http$new("https://example.com", NULL)
-  expect_equal(loc$client$authorise(), NULL)
   expect_equal(loc$client$url, "https://example.com")
 })
 

--- a/tests/testthat/test-zzz-location-http.R
+++ b/tests/testthat/test-zzz-location-http.R
@@ -152,7 +152,7 @@ describe("http location integration tests", {
     )
 
     ## Trigger the error directly:
-    cl <- outpack_http_client$new(url, NULL)
+    cl <- outpack_http_client$new(url)
     err <- expect_error(
       cl$request(sprintf("/packet/%s", hash),
                  function(r) httr2::req_body_raw(r, meta, "text/plain")),


### PR DESCRIPTION
In the past orderly2 would perform device flow authentication against GitHub, retrieve a GitHub token and use that to trade it against a Packit token.

Packit now supports device flow authentication natively. Orderly2 can directly get a Packit token, without having to trade anything. If necessary, the device flow may involve logging in to Packit via GitHub, but that happens in the user's browser and is completely transparent from the user's perspective.

It also means the authentication is completely standard and works with the off-the-shelf components from httr2. We do not have to think about caching the Packit token anymore, as that is now done automatically by httr2.

We also probably do not need to worry about expiry and renewals, which is something that we had never handled properly (the tokens were only cached in memory, so restarting the R session regularly avoided this problem). httr2 will automatically initiate authentication when a new token is needed.

The old authentication method has been removed from orderly2 completely. We will wait until all Packit instances support device-flow before merging this change.