### PR TITLE
Self-destruct orderly example directories after use

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: orderly2
 Title: Lightweight Reproducible Reporting
-Version: 1.99.76
+Version: 1.99.77
 Authors@R: c(person("Rich", "FitzJohn", role = c("aut", "cre"),
                     email = "rich.fitzjohn@gmail.com"),
              person("Robert", "Ashton", role = "aut"),

--- a/R/cleanup.R
+++ b/R/cleanup.R
@@ -65,8 +65,6 @@
 ##'
 ##' # Do the actual deletion:
 ##' orderly2::orderly_cleanup("data", root = path)
-##'
-##' fs::dir_delete(path)
 orderly_cleanup <- function(name = NULL, dry_run = FALSE, root = NULL) {
   status <- orderly_cleanup_status(name, root)
   n <- length(status$delete)

--- a/R/example.R
+++ b/R/example.R
@@ -10,10 +10,10 @@
 ##'   "simple" and "demo" are supported.
 ##'
 ##' @param dest The destination. By default we use
-##'   `withr::local_tempfile()` which will create a temporary
-##'   directory that will clean itself up. This is suitable for use
-##'   from the orderly examples, but you may prefer to provide your
-##'   own path. The path must not already exist.
+##'   `withr::local_tempdir()` which will create a temporary directory
+##'   that will clean itself up. This is suitable for use from the
+##'   orderly examples, but you may prefer to provide your own path,
+##'   in which case the path must not already exist.
 ##'
 ##' @param ... Arguments passed through to [orderly2::orderly_init()]
 ##'
@@ -22,11 +22,10 @@
 ##' @examples
 ##' path <- orderly_example()
 ##' orderly_list_src(root = path)
-##'
-##' fs::dir_delete(path)
 orderly_example <- function(..., names = NULL, example = "demo", dest = NULL) {
   if (is.null(dest)) {
-    dest <- tempfile("orderly2_ex_")
+    env <- find_calling_env("source")
+    dest <- withr::local_tempdir(pattern = "orderly2_ex_", .local_envir = env)
   } else {
     assert_scalar_character(dest)
     if (file.exists(dest)) {

--- a/R/orderly.R
+++ b/R/orderly.R
@@ -17,7 +17,6 @@
 ##' @examples
 ##' path <- orderly_example()
 ##' orderly_list_src(root = path)
-##' fs::dir_delete(path)
 orderly_list_src <- function(root = NULL) {
   root_path <- orderly_src_root(root)
   if (!file.exists(file.path(root_path, "src"))) {

--- a/R/run.R
+++ b/R/run.R
@@ -150,9 +150,6 @@
 ##'
 ##' # and we can query the metadata:
 ##' orderly_metadata_extract(name = "data", root = path)
-##'
-##' # Cleanup
-##' fs::dir_delete(path)
 orderly_run <- function(name, parameters = NULL, envir = NULL, echo = TRUE,
                         location = NULL, allow_remote = NULL,
                         fetch_metadata = FALSE, search_options = NULL,

--- a/R/util.R
+++ b/R/util.R
@@ -827,3 +827,23 @@ show_file <- function(filename, title = filename, language = "R") {
   cli::cli_h1(title)
   cli::cli_code(code)
 }
+
+
+## There might be an easier way of doing this, but it's not totally
+## obvious.  We want to search through the calls to find a plausible
+## match for some function 'fn' (in the case where we use this,
+## "source", as we're trying to find the environment that triggers
+## running an example - this is called by "example()" and by devtools'
+## example runner).
+##
+## The approach here is simply to look at the stack and if there's one
+## call to that function use that; don't try and be clever and find
+## the shallowest or deepest in the case where more than one is
+## present.  If we fail, return the global environment, which is
+## suitable for using as .local_envir in withr functions anyway but
+## requires manual cleanup.
+find_calling_env <- function(fn) {
+  calls <- sys.calls()
+  i <- which(vlapply(calls, function(x) rlang::is_call(x, fn)))
+  if (length(i) == 1) sys.frame(i) else globalenv()
+}

--- a/man/orderly_cleanup.Rd
+++ b/man/orderly_cleanup.Rd
@@ -83,6 +83,4 @@ orderly2::orderly_cleanup_status("data", root = path)
 
 # Do the actual deletion:
 orderly2::orderly_cleanup("data", root = path)
-
-fs::dir_delete(path)
 }

--- a/man/orderly_example.Rd
+++ b/man/orderly_example.Rd
@@ -16,10 +16,10 @@ default is to copy all reports.}
 "simple" and "demo" are supported.}
 
 \item{dest}{The destination. By default we use
-\code{withr::local_tempfile()} which will create a temporary
-directory that will clean itself up. This is suitable for use
-from the orderly examples, but you may prefer to provide your
-own path. The path must not already exist.}
+\code{withr::local_tempdir()} which will create a temporary directory
+that will clean itself up. This is suitable for use from the
+orderly examples, but you may prefer to provide your own path,
+in which case the path must not already exist.}
 }
 \value{
 Invisibly, the path to the example.
@@ -31,6 +31,4 @@ should not form part of your workflow!
 \examples{
 path <- orderly_example()
 orderly_list_src(root = path)
-
-fs::dir_delete(path)
 }

--- a/man/orderly_list_src.Rd
+++ b/man/orderly_list_src.Rd
@@ -26,7 +26,6 @@ as the directory (e.g., \code{src/data/data.R} corresponds to \code{data}).
 \examples{
 path <- orderly_example()
 orderly_list_src(root = path)
-fs::dir_delete(path)
 }
 \seealso{
 \link{orderly_metadata_extract} for listing packets

--- a/man/orderly_run.Rd
+++ b/man/orderly_run.Rd
@@ -197,7 +197,4 @@ fs::dir_tree(path)
 
 # and we can query the metadata:
 orderly_metadata_extract(name = "data", root = path)
-
-# Cleanup
-fs::dir_delete(path)
 }

--- a/tests/testthat/test-util.R
+++ b/tests/testthat/test-util.R
@@ -605,3 +605,29 @@ test_that("can make a strict list", {
   expect_error(obj[c("apple", "banan")],
                "'banan' not found in 'obj'")
 })
+
+
+test_that("can find calling env", {
+  ## The curly braces here are required, otherwise we don't properly
+  ## come through with calls that can be processed by find_calling_env :-/
+  f1 <- function(nm) {
+    f2(nm)
+  }
+  f2 <- function(nm) {
+    f3(nm)
+  }
+  f3 <- function(nm) {
+    f4(nm)
+  }
+  f4 <- function(nm) {
+    f5(nm)
+  }
+  f5 <- function(nm) {
+    env <- find_calling_env(nm)
+    calls <- sys.calls()
+    which(vlapply(calls, function(e) identical(e, env)))
+  }
+
+  expect_equal(f1("foo"), integer(0))
+  expect_equal(f1("f2"), integer(0))
+})


### PR DESCRIPTION
A small thing which harmonises the docs and the implementation for examples.  There's a bit of a faff in implementation here to work out which environment to register the destructor with, but after a bit of experimentation I came up with something that works