### PR TITLE
Allow orderly_dependency to be used with an empty list of files.

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: orderly2
 Title: Lightweight Reproducible Reporting
-Version: 1.99.78
+Version: 1.99.79
 Authors@R: c(person("Rich", "FitzJohn", role = c("aut", "cre"),
                     email = "rich.fitzjohn@gmail.com"),
              person("Robert", "Ashton", role = "aut"),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -37,6 +37,7 @@ Imports:
     openssl,
     rlang,
     rstudioapi,
+    vctrs,
     withr,
     yaml
 Suggests:

--- a/R/util.R
+++ b/R/util.R
@@ -96,7 +96,7 @@ drop_null <- function(x, empty) {
 replace_ragged <- function(x, i, values) {
   ret <- as.list(x)
   ret[i] <- values
-  unlist(ret, FALSE, FALSE)
+  vctrs::list_unchop(ret, ptype = vctrs::vec_ptype(x))
 }
 
 

--- a/tests/testthat/test-outpack-helpers.R
+++ b/tests/testthat/test-outpack-helpers.R
@@ -242,3 +242,13 @@ test_that("disallow duplicate files that point to different places", {
       dest = dst, root = path),
     "Directory expansion would result in overwritten files")
 })
+
+test_that("can copy an empty list of files", {
+  root <- create_temporary_root()
+  id <- create_random_packet(root)
+
+  dst <- withr::local_tempdir()
+
+  res <- orderly_copy_files(id, files = character(0), dest = dst, root = root)
+  expect_equal(res$files, data_frame(here = character(0), there = character(0)))
+})

--- a/tests/testthat/test-run.R
+++ b/tests/testthat/test-run.R
@@ -1447,3 +1447,19 @@ test_that("interactively run a packet with legacy parameters", {
   expect_true(file.exists(path_rds))
   expect_equal(readRDS(path_rds), list(a = 10, b = 2, c = 30))
 })
+
+
+test_that("can add a dependency with an empty list of files", {
+  root <- create_temporary_root()
+  id1 <- create_random_packet(root, name = "data")
+
+  id2 <- orderly_run_snippet(root, "downstream", {
+    dep <- orderly_dependency("data", "latest", files = character(0))
+    saveRDS(dep, "data.rds")
+  })
+
+  res <- readRDS(file.path(root$path, "archive", "downstream", id2, "data.rds"))
+  expect_equal(res$id, id1)
+  expect_equal(res$name, "data")
+  expect_equal(res$files, data.frame(here=character(0), there=character(0)))
+})

--- a/tests/testthat/test-run.R
+++ b/tests/testthat/test-run.R
@@ -1461,5 +1461,5 @@ test_that("can add a dependency with an empty list of files", {
   res <- readRDS(file.path(root$path, "archive", "downstream", id2, "data.rds"))
   expect_equal(res$id, id1)
   expect_equal(res$name, "data")
-  expect_equal(res$files, data.frame(here=character(0), there=character(0)))
+  expect_equal(res$files, data.frame(here = character(0), there = character(0)))
 })

--- a/tests/testthat/test-util.R
+++ b/tests/testthat/test-util.R
@@ -331,7 +331,7 @@ describe("expand_dirs_virtual", {
   list_files <- function(p) files[[p]]
 
   check <- function(object, expected) {
-    expect_equal(expand_dirs_virtual(object, is_dir, list_files), expected)
+    expect_equal(expand_dirs_virtual(!!object, is_dir, list_files), !!expected)
   }
 
   it("accepts a character vector", {
@@ -365,6 +365,12 @@ describe("expand_dirs_virtual", {
       data_frame(here = c("foo", "bar"), there = c("d2", "d2")),
       data_frame(here = c("foo/f4", "foo/d3/f5", "bar/f4", "bar/d3/f5"),
                  there = c("d2/f4", "d2/d3/f5", "d2/f4", "d2/d3/f5")))
+  })
+
+  it("accepts an empty input", {
+     check(character(0), character(0))
+     check(data_frame(here = character(0), there = character(0)),
+           data_frame(here = character(0), there = character(0)))
   })
 })
 
@@ -643,4 +649,19 @@ test_that("can find calling env", {
   }
   expect_false(f1("foo"))
   expect_true(f1("f2"))
+})
+
+test_that("replace_ragged with an empty result preserves the input's type", {
+  # Even with an empty input, the type of it should be preserved
+  result <- replace_ragged(character(0), numeric(0), list())
+  expect_vector(result, ptype = character(), size = 0)
+  result <- replace_ragged(numeric(0), numeric(0), list())
+  expect_vector(result, ptype = numeric(), size = 0)
+
+  # With a non-empty input but an empty result following replacement, the
+  # type should also be preserved
+  result <- replace_ragged(12, 1, list(numeric(0)))
+  expect_vector(result, ptype = numeric(), size = 0)
+  result <- replace_ragged("foo", 1, list(numeric(0)))
+  expect_vector(result, ptype = character(), size = 0)
 })


### PR DESCRIPTION
This is definitely a niche use case, but I don't see a good reason not to support it. For the most part, everything worked already.

The only issue was the `ragged_replace` function which returned NULL when the output was empty instead of a vector of the original type. This would cause columns to be missing from data frames (`dataframe(x = NULL)` has no columns, rather than an empty `x`), as well as cause problems with `fs` functions (eg. `fs::file_exists(NULL)` is an error, but `fs::file_exists(character(0))` works and returns an empty logical vector).

Using the vctrs package makes it easy to write code that has consistent and predictable types. httr2 already depends on that package, so it is not actually a new dependency.