### PR TITLE
Fix the documentation of orderly_copy_files (and related).

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: orderly2
 Title: Lightweight Reproducible Reporting
-Version: 1.99.80
+Version: 1.99.81
 Authors@R: c(person("Rich", "FitzJohn", role = c("aut", "cre"),
                     email = "rich.fitzjohn@gmail.com"),
              person("Robert", "Ashton", role = "aut"),

--- a/R/outpack_helpers.R
+++ b/R/outpack_helpers.R
@@ -38,15 +38,12 @@
 ##'
 ##' @title Copy files from a packet
 ##'
-##' @param files Files to copy from the other packet. This can be (1)
-##'   a character vector, in which case files are copied over without
-##'   changing their names, (2) a **named** character vector, in which
-##'   case the name will be used as the destination name, or (3) a
-##'   [data.frame] (including `tbl_df`, or `data.frame` objects)
-##'   containing columns `from` and `to`, in which case the files
-##'   `from` will be copied with names `to`.
+##' @param files Files to copy from the other packet, as a character vector.
+##'   If the character vector is unnamed, the files listed are copied over
+##'   without changing their names. If the vector is named however, the names
+##'   will be used as the destination name for the files.
 ##'
-##' In all cases, if you want to import a directory of files from a
+##' In either case, if you want to import a directory of files from a
 ##'   packet, you must refer to the source with a trailing slash
 ##'   (e.g., `c(here = "there/")`), which will create the local
 ##'   directory `here/...` with files from the upstream packet

--- a/R/outpack_packet.R
+++ b/R/outpack_packet.R
@@ -114,34 +114,6 @@ outpack_packet_end <- function(packet, insert = TRUE) {
 ##' @param query An [orderly2::orderly_query] object, or something
 ##'   (e.g., a string) that can be trivially converted into one.
 ##'
-##' @param files Files to copy from the other packet. This can be (1)
-##'   a character vector, in which case files are copied over without
-##'   changing their names, (2) a **named** character vector, in which
-##'   case the name will be used as the destination name, or (3) a
-##'   [data.frame] (including `tbl_df`, or `data.frame` objects)
-##'   containing columns `from` and `to`, in which case the files
-##'   `from` will be copied with names `to`.
-##'
-##' In all cases, if you want to import a directory of files from a
-##'   packet, you must refer to the source with a trailing slash
-##'   (e.g., `c(here = "there/")`), which will create the local
-##'   directory `here/...` with files from the upstream packet
-##'   directory `there/`. If you omit the slash then an error will be
-##'   thrown suggesting that you add a slash if this is what you
-##'   intended.
-##'
-##' You can use a limited form of string interpolation in the names of
-##'   this argument; using `${variable}` will pick up values from
-##'   `envir` and substitute them into your string.  This is similar
-##'   to the interpolation you might be familiar with from
-##'   `glue::glue` or similar, but much simpler with no concatenation
-##'   or other fancy features supported.
-##'
-##' Note that there is an unfortunate, but (to us) avoidable
-##'   inconsistency here; interpolation of values from your
-##'   environment in the query is done by using `environment:x` and in
-##'   the destination filename by doing `${x}`.
-##'
 ##' @param search_options Optional search options for restricting the
 ##'   search (see [orderly2::orderly_search] for details)
 ##'
@@ -156,6 +128,7 @@ outpack_packet_end <- function(packet, insert = TRUE) {
 ##'   typically what you want, but set to `FALSE` if you would prefer
 ##'   that an error be thrown if the destination file already exists.
 ##'
+##' @inheritParams orderly_copy_files
 ##' @noRd
 outpack_packet_use_dependency <- function(packet, query, files,
                                           envir = parent.frame(),

--- a/man/orderly_copy_files.Rd
+++ b/man/orderly_copy_files.Rd
@@ -22,15 +22,12 @@ orderly_copy_files(
 \arguments{
 \item{expr}{The query expression. A \code{NULL} expression matches everything.}
 
-\item{files}{Files to copy from the other packet. This can be (1)
-a character vector, in which case files are copied over without
-changing their names, (2) a \strong{named} character vector, in which
-case the name will be used as the destination name, or (3) a
-\link{data.frame} (including \code{tbl_df}, or \code{data.frame} objects)
-containing columns \code{from} and \code{to}, in which case the files
-\code{from} will be copied with names \code{to}.
+\item{files}{Files to copy from the other packet, as a character vector.
+If the character vector is unnamed, the files listed are copied over
+without changing their names. If the vector is named however, the names
+will be used as the destination name for the files.
 
-In all cases, if you want to import a directory of files from a
+In either case, if you want to import a directory of files from a
 packet, you must refer to the source with a trailing slash
 (e.g., \code{c(here = "there/")}), which will create the local
 directory \code{here/...} with files from the upstream packet

--- a/man/orderly_dependency.Rd
+++ b/man/orderly_dependency.Rd
@@ -13,15 +13,12 @@ orderly_dependency(name, query, files)
 the string \code{latest}, indicating the most recent version. You may
 want a more complex query here though.}
 
-\item{files}{Files to copy from the other packet. This can be (1)
-a character vector, in which case files are copied over without
-changing their names, (2) a \strong{named} character vector, in which
-case the name will be used as the destination name, or (3) a
-\link{data.frame} (including \code{tbl_df}, or \code{data.frame} objects)
-containing columns \code{from} and \code{to}, in which case the files
-\code{from} will be copied with names \code{to}.
+\item{files}{Files to copy from the other packet, as a character vector.
+If the character vector is unnamed, the files listed are copied over
+without changing their names. If the vector is named however, the names
+will be used as the destination name for the files.
 
-In all cases, if you want to import a directory of files from a
+In either case, if you want to import a directory of files from a
 packet, you must refer to the source with a trailing slash
 (e.g., \code{c(here = "there/")}), which will create the local
 directory \code{here/...} with files from the upstream packet


### PR DESCRIPTION
The documentation was claiming that the `files` argument can be a dataframe with here and there columns, but that is not actually the case. Only character vectors (and lists for some reason) are actually supported.

The function that processes the files list is `validate_file_from_to` and has the following comment:

> Later, we can expand this to support a data.frame too perhaps?

Until then we shouldn't be advertising an inexistent feature.