### PR TITLE
Detect issues with interactive use of orderly_parameters.

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: orderly2
 Title: Lightweight Reproducible Reporting
-Version: 1.99.79
+Version: 1.99.80
 Authors@R: c(person("Rich", "FitzJohn", role = c("aut", "cre"),
                     email = "rich.fitzjohn@gmail.com"),
              person("Robert", "Ashton", role = "aut"),

--- a/R/context.R
+++ b/R/context.R
@@ -8,7 +8,8 @@ orderly_context <- function(envir) {
     config <- p$orderly2$config
     envir <- p$orderly2$envir
     src <- p$orderly2$src
-    parameters <- p$parameters
+    parameters_values <- p$parameters
+    parameters_spec <- NULL
     name <- p$name
     id <- p$id
     search_options <- p$orderly2$search_options
@@ -19,14 +20,16 @@ orderly_context <- function(envir) {
     config <- orderly_config_read(root)
     src <- path
     parameters <- current_orderly_parameters(src, envir)
+    parameters_values <- parameters$values
+    parameters_spec <- parameters$spec
     name <- basename(path)
     id <- NA_character_
     search_options <- .interactive$search_options
   }
   list(is_active = is_active, path = path, config = config, envir = envir,
-       root = root, root_src = root_src, src = src, name = name,
-       id = id, parameters = parameters, search_options = search_options,
-       packet = p)
+       root = root, root_src = root_src, src = src, name = name, id = id,
+       parameters = parameters_values, parameters_spec = parameters_spec,
+       search_options = search_options, packet = p)
 }
 
 

--- a/tests/testthat/test-run.R
+++ b/tests/testthat/test-run.R
@@ -1463,3 +1463,20 @@ test_that("can add a dependency with an empty list of files", {
   expect_equal(res$name, "data")
   expect_equal(res$files, data.frame(here = character(0), there = character(0)))
 })
+
+
+test_that("detect mismatched orderly_parameters when running interactively", {
+  path <- test_prepare_orderly_example("parameters")
+  path_src <- file.path(path, "src", "parameters")
+
+  pars <- strict_list(a = 10, b = 20, c = 30, .name = "parameters")
+
+  # The actual report only has parameters a, b, and c. Act as though we have
+  # modified the file in our text editor and added a fourth parameter, and run
+  # it interactively line-by-line with Ctrl-Enter without saving it first.
+  expect_error(withr::with_dir(path_src, {
+    suppressMessages(orderly2::orderly_parameters(a = NULL, b = 2,
+                                                  c = NULL, d = 4))
+  }), paste("Arguments to `orderly_parameters` do not match the ones read",
+            "from source file .*/parameters.R"))
+})


### PR DESCRIPTION
When `orderly_parameters` is called, we actually ignore its arguments and instead use the invocation of it found in the source file of the report. We do this because we need to know the name of the variable the parameters are assigned to, which cannot be done just from looking at the arguments.

This can cause issues when running interactively in RStudio, running line-by-line with Ctrl-Enter but without saving the file first. The user may have added a parameter, not saved the file and run the `orderly_parameters` line. orderly would use the list of parameters it finds on disk instead of the ones in the text editor's buffer.

We could be really clever and use the RStudio API to read the unsaved buffer instead, but that's a bit over the top and won't work with other IDEs that have a similar interactive interface.

The easy solution is to compare the arguments given to orderly_parameters against the ones that were read from the on-disk file, and throw an error if these don't match.