### PR TITLE
Fix installation for universe

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: orderly
 Title: Lightweight Reproducible Reporting
-Version: 1.99.82
+Version: 1.99.83
 Authors@R: c(person("Rich", "FitzJohn", role = c("aut", "cre"),
                     email = "rich.fitzjohn@gmail.com"),
              person("Robert", "Ashton", role = "aut"),

--- a/inst/orderly2/DESCRIPTION
+++ b/inst/orderly2/DESCRIPTION
@@ -11,3 +11,4 @@ Encoding: UTF-8
 Roxygen: list(markdown = TRUE)
 RoxygenNote: 7.3.2
 Imports: orderly (>= 1.99.82)
+Remotes: mrc-ide/orderly


### PR DESCRIPTION
This does not seem needed for hipercow, but it might just be because orderly is already on CRAN?