### PR TITLE
Fixes for CRAN

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: orderly
 Title: Lightweight Reproducible Reporting
-Version: 2.0.2
+Version: 2.0.3
 Authors@R: c(person("Rich", "FitzJohn", role = c("aut", "cre"),
                     email = "rich.fitzjohn@gmail.com"),
              person("Robert", "Ashton", role = "aut"),

--- a/tests/testthat/test-util.R
+++ b/tests/testthat/test-util.R
@@ -673,8 +673,6 @@ test_that("replace_ragged with an empty result preserves the input's type", {
   # type should also be preserved
   result <- replace_ragged(12, 1, list(numeric(0)))
   expect_vector(result, ptype = numeric(), size = 0)
-  result <- replace_ragged("foo", 1, list(numeric(0)))
-  expect_vector(result, ptype = character(), size = 0)
 })
 
 


### PR DESCRIPTION
This PR fixes the build on CRAN (failing [here](https://cran.r-project.org/web/checks/check_results_orderly.html)) as vctrs has changed behaviour to fix a bug (reported in #250). Unfortunately, despite the nice warning that the breaking change was coming via GitHub, none of us have noticed and no email to the mantainer address was sent, so the first I knew about this was a `message` from CRAN, but thankfully this time I was not on holiday.

I suspect the offending test was put in by Paul to make sure that we could rely on the package not doing something odd in a corner case but I must admit that I've not dug back into this, nor can I remember the specifics (just that the bookkeeping was somewhat tedious).

See a failing build on be68768 with the same message as CRAN - this was just with a version bump, this is fixed in 
ed3f1eb which simply removes the offending test.

I've uploaded to win builder to do a pre-flight test on r-devel and` that's come back OK: https://win-builder.r-project.org/L4bIUTDv08Dn/

Can you look at this please @weshinsley or @EmmaLRussell (or anyone else interested) and I'll get the package sent back up before it meets its demise

Fixes #250

Also fixes the failing r-universe build, which now uses the updated version of `vctrs`